### PR TITLE
parse version message

### DIFF
--- a/lib/bitcoin/connection.rb
+++ b/lib/bitcoin/connection.rb
@@ -42,8 +42,9 @@ module Bitcoin
       #puts block.to_json
     end
 
-    def on_version(payload)
-      p [@sockaddr, 'version']
+    def on_version(version, services, timestamp, block)
+      p [@sockaddr, 'version', {:version => version, :block => block,
+           :timediff => timestamp - Time.now.to_i}]
       send_data( Protocol.verack_pkt )
     end
 

--- a/lib/bitcoin/protocol/parser.rb
+++ b/lib/bitcoin/protocol/parser.rb
@@ -56,7 +56,15 @@ module Bitcoin
       end
 
       def parse_version(payload)
-        @h.on_version(payload)
+        idx = 0
+        version = payload[idx...idx+=4].unpack("I*")[0]
+        services = payload[idx...idx+=8]
+        timestamp = payload[idx...idx+=8].unpack("I*")[0]
+        to = payload[idx...idx+=26] #.unpack("I*")
+        from = payload[idx...idx+=26] #.unpack("I*")
+        block = payload[-4..-1].unpack("I*")[0]
+
+        @h.on_version(version, services, timestamp, block)
       end
 
       def parse(buf)
@@ -79,6 +87,7 @@ module Bitcoin
 
           if ['version', 'verack'].include?(cmd)
             head_size -= 4
+            payload = @buf[head_size...head_size+length]
           else
             if Digest::SHA256.digest(Digest::SHA256.digest( payload ))[0...4] != checksum
               if (length < 50000) && (payload.size < length)

--- a/spec/bitcoin/protocol/version_spec.rb
+++ b/spec/bitcoin/protocol/version_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../spec_helper.rb'
+
+describe 'Bitcoin::Protocol::Parser (version)' do
+
+  it 'parses version' do
+    pkt = [
+      "f9 be b4 d9 76 65 72 73 69 6f 6e 00 00 00 00 00 55 00 00 00 40 9c 00 00 01 00 00 00 00 00 00 00 10 42 c9 4e 00 00 00 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ff ff 7f 00 00 01 04 d2 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ff ff 7f 00 00 01 47 9d 4b b8 bb 21 ae d7 f0 71 00 fa 00 00 00"
+      .split(" ").join].pack("H*")
+
+    class Version_Handler < Bitcoin::Protocol::Handler
+      attr_reader :version, :services, :timestamp, :block
+      def on_version(version, services, timestamp, block)
+        @version, @services, @timestamp, @block =
+          version, services, timestamp, block
+      end
+    end
+
+    parser = Bitcoin::Protocol::Parser.new( handler = Version_Handler.new )
+    parser.parse(pkt + "AAAA").should == "AAAA"
+
+    handler.version.should == 40000
+    handler.services.should == ["01 00 00 00 00 00 00 00".split(' ').join].pack("H*")
+    handler.timestamp.should == 1321812496
+    handler.block.should == 250
+  end
+
+end


### PR DESCRIPTION
parse the version message and pass arguments to the on_version callback.

had to adjust the #parse method to return a different payload for version calls, otherwise the actual version isn't included in the payload.

the services field is returned in raw form now; how would that best be represented in ruby?

also i don't know how to parse the from/to addresses...

lastly, i had to fix the payload passed from #parse for version messages, to get the version 
