### PR TITLE
add hash160_to_p2sh_address utility method

### DIFF
--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -112,7 +112,15 @@ module Bitcoin
     end
 
     def hash160_to_address(hex)
-      hex = address_version + hex
+      encode_address hex, address_version
+    end
+
+    def hash160_to_p2sh_address(hex)
+      encode_address hex, p2sh_version
+    end
+
+    def encode_address(hex, version)
+      hex = version + hex
       encode_base58(hex + checksum(hex))
     end
 

--- a/spec/bitcoin/bitcoin_spec.rb
+++ b/spec/bitcoin/bitcoin_spec.rb
@@ -24,6 +24,16 @@ describe 'Bitcoin Address/Hash160/PubKey' do
       .should == "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
   end
 
+  it 'bitcoin p2sh address from bitcoin-hash160' do
+    Bitcoin::network = :testnet
+    Bitcoin.hash160_to_p2sh_address("d11e2f2f385efeecd30f867f1d55c0bc8a27f29e")
+      .should == "2NCJwNct2SVE5VwdrPXmnek59kCfdgCpxeF"
+
+    Bitcoin::network = :bitcoin
+    Bitcoin.hash160_to_p2sh_address("d11e2f2f385efeecd30f867f1d55c0bc8a27f29e")
+      .should == "3LkjJswzq2ijJA1JiQ9v2o5tXrTTvPtAMe"
+  end
+
   it 'bitcoin-hash160 from bitcoin-address' do
     Bitcoin::network = :testnet
     Bitcoin.hash160_from_address("mpXwg4jMtRhuSpVq4xS3HFHmCmWp9NyGKt")


### PR DESCRIPTION
I'm not very sure about the naming of these methods. Let me know if they need updating.

With this utility method, one won't need to do things like 

``` ruby
hex = Bitcoin.p2sh_version + p2sh_hash
Bitcoin.encode_base58(hex + Bitcoin.checksum(hex))
```
