### PR TITLE
add privkey to wif utility method

### DIFF
--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -62,6 +62,7 @@ module Bitcoin
 
     def address_version; Bitcoin.network[:address_version]; end
     def p2sh_version; Bitcoin.network[:p2sh_version]; end
+    def privkey_version; Bitcoin.network[:privkey_version]; end
 
     # hash160 is a 20 bytes (160bits) rmd610-sha256 hexdigest.
     def hash160(hex)
@@ -126,6 +127,11 @@ module Bitcoin
 
     def pubkey_to_address(pubkey)
       hash160_to_address( hash160(pubkey) )
+    end
+
+    def privkey_to_wif(privkey)
+      extended_pk = privkey_version + privkey
+      encode_base58(extended_pk + checksum(extended_pk))
     end
 
     def int_to_base58(int_val, leading_zero_bytes=0)

--- a/spec/bitcoin/bitcoin_spec.rb
+++ b/spec/bitcoin/bitcoin_spec.rb
@@ -24,6 +24,16 @@ describe 'Bitcoin Address/Hash160/PubKey' do
       .should == "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
   end
 
+  it 'private key to wallet import format (WIF)' do
+    privkey = "636000ddadd56d0dc5d30ce91b8fbd3ca033ba5320586b6c2ed0c37c4f63b5d8"
+
+    Bitcoin::network = :bitcoin
+    Bitcoin.privkey_to_wif(privkey).should == "5Ja3yxYnP7cajfotd8az6YTjJopwQDk5sGtMyhGR6pzXnGamemq"
+
+    Bitcoin::network = :testnet
+    Bitcoin.privkey_to_wif(privkey).should == "92LgZhNKyLgihjKBFUUty91gxUBeZPHHDDkK4KcvSZjaZHSKphQ"
+  end
+
   it 'bitcoin p2sh address from bitcoin-hash160' do
     Bitcoin::network = :testnet
     Bitcoin.hash160_to_p2sh_address("d11e2f2f385efeecd30f867f1d55c0bc8a27f29e")


### PR DESCRIPTION
Allow conversion of private key to Wallet Import Format as specified
here: https://en.bitcoin.it/wiki/Wallet_import_format

I looked to see if something like this was already implemented in this library, but I couldn't find it.
