### PR TITLE
storage: check for existing blocks only in mainchain

### DIFF
--- a/lib/bitcoin/storage/sequel/sequel_store.rb
+++ b/lib/bitcoin/storage/sequel/sequel_store.rb
@@ -209,9 +209,9 @@ module Bitcoin::Storage::Backends
       end
     end
 
-    # check if block +blk_hash+ exists
+    # check if block +blk_hash+ exists in the main chain
     def has_block(blk_hash)
-      !!@db[:blk].where(:hash => blk_hash.htb.blob).get(1)
+      !!@db[:blk].where(:hash => blk_hash.htb.blob, :chain => 0).get(1)
     end
 
     # check if transaction +tx_hash+ exists


### PR DESCRIPTION
this solves a reorg issue when the node thinks the current chain head is already stored - and it is, but as a side-chain block. In that case it should still try to sort the block in the branch it belongs.

https://github.com/lian/bitcoin-ruby/issues/78
