### PR TITLE
Default to using compressed pubkeys

### DIFF
--- a/lib/bitcoin/key.rb
+++ b/lib/bitcoin/key.rb
@@ -32,11 +32,11 @@ module Bitcoin
     #  Bitcoin::Key.new
     #  Bitcoin::Key.new(privkey)
     #  Bitcoin::Key.new(nil, pubkey)
-    def initialize privkey = nil, pubkey = nil, compressed = false
+    def initialize privkey = nil, pubkey = nil, compressed = true
       @key = Bitcoin.bitcoin_elliptic_curve
       @pubkey_compressed = pubkey ? self.class.is_compressed_pubkey?(pubkey) : compressed
       set_priv(privkey)  if privkey
-      set_pub(pubkey)  if pubkey
+      set_pub(pubkey, @pubkey_compressed)  if pubkey
     end
 
     # Generate new priv/pub key.
@@ -59,21 +59,17 @@ module Bitcoin
     # In case the key was initialized with only
     # a private key, the public key is regenerated.
     def pub
+      regenerate_pubkey unless @key.public_key
+      return nil        unless @key.public_key
       @pubkey_compressed ? pub_compressed : pub_uncompressed
     end
 
     def pub_compressed
-      regenerate_pubkey unless @key.public_key
-      return nil        unless @key.public_key
       @key.public_key.group.point_conversion_form = :compressed
-      hex = @key.public_key.to_hex.rjust(66, '0')
-      @key.public_key.group.point_conversion_form = :uncompressed
-      hex
+      @key.public_key.to_hex.rjust(66, '0')
     end
 
     def pub_uncompressed
-      regenerate_pubkey unless @key.public_key
-      return nil        unless @key.public_key
       @key.public_key.group.point_conversion_form = :uncompressed
       @key.public_key.to_hex.rjust(130, '0')
     end
@@ -99,7 +95,7 @@ module Bitcoin
 
     # Sign +data+ with the key.
     #  key1 = Bitcoin::Key.generate
-    #  sig = key.sign("some data")
+    #  sig = key1.sign("some data")
     def sign(data)
       @key.dsa_sign_asn1(data)
     end
@@ -167,7 +163,7 @@ module Bitcoin
     # Regenerate public key from the private key.
     def regenerate_pubkey
       return nil unless @key.private_key
-      set_pub(Bitcoin::OpenSSL_EC.regenerate_key(priv)[1])
+      set_pub(Bitcoin::OpenSSL_EC.regenerate_key(priv)[1], @pubkey_compressed)
     end
 
     # Set +priv+ as the new private key (converting from hex).
@@ -176,8 +172,8 @@ module Bitcoin
     end
 
     # Set +pub+ as the new public key (converting from hex).
-    def set_pub(pub)
-      @pubkey_compressed ||= self.class.is_compressed_pubkey?(pub)
+    def set_pub(pub, compressed = nil)
+      @pubkey_compressed = compressed == nil ? self.class.is_compressed_pubkey?(pub) : compressed
       @key.public_key = OpenSSL::PKey::EC::Point.from_hex(@key.group, pub)
     end
 

--- a/spec/bitcoin/key_spec.rb
+++ b/spec/bitcoin/key_spec.rb
@@ -8,14 +8,14 @@ describe "Bitcoin::Key" do
     Bitcoin.network = :bitcoin
     @key_data = {
       :priv => "2ebd3738f59ae4fd408d717bf325b4cb979a409b0153f6d3b4b91cdfe046fb1e",
-      :pub => "045fcb2fb2802b024f371cc22bc392268cc579e47e7936e0d1f05064e6e1103b8a81954eb6d3d33b8b6e73e9269013e843e83919f7ce4039bb046517a0cad5a3b1" }
-    @key = Bitcoin::Key.new(@key_data[:priv], @key_data[:pub])
+      :pub => "035fcb2fb2802b024f371cc22bc392268cc579e47e7936e0d1f05064e6e1103b8a" }
+    @key = Bitcoin::Key.new(@key_data[:priv], @key_data[:pub], false)
   end
 
   it "should generate a key" do
     k = Bitcoin::Key.generate
     k.priv.size.should == 64
-    k.pub.size.should == 130
+    k.pub.size.should == 66
     #p k.priv, k.pub
   end
 
@@ -56,6 +56,8 @@ describe "Bitcoin::Key" do
   end
 
   it "should get addr" do
+    @key.addr.should == "19CyxBz6CUBogxTdSXUrbRHo7T7eLCMgbr"
+    @key.instance_eval { @pubkey_compressed = false }
     @key.addr.should == "1JbYZRKyysprVjSSBobs8LX6QVjzsscQNU"
   end
 
@@ -103,10 +105,10 @@ describe "Bitcoin::Key" do
 
   it "should export private key in base58 format" do
     Bitcoin.network = :bitcoin
-    str = Bitcoin::Key.new("e9873d79c6d87dc0fb6a5778633389f4453213303da61f20bd67fc233aa33262").to_base58
+    str = Bitcoin::Key.new("e9873d79c6d87dc0fb6a5778633389f4453213303da61f20bd67fc233aa33262", nil, false).to_base58
     str.should == "5Kb8kLf9zgWQnogidDA76MzPL6TsZZY36hWXMssSzNydYXYB9KF"
     Bitcoin.network = :testnet
-    str = Bitcoin::Key.new("d21fa2c7ad710ffcd9bcc22a9f96357bda1a2521ca7181dd610140ecea2cecd8").to_base58
+    str = Bitcoin::Key.new("d21fa2c7ad710ffcd9bcc22a9f96357bda1a2521ca7181dd610140ecea2cecd8", nil, false).to_base58
     str.should == "93BTVFoqffueSaC5fqjLjLyn29S41JzvAZm2hC35SYMoYDXT1bY"
     Bitcoin.network = :bitcoin
   end
@@ -130,13 +132,15 @@ describe "Bitcoin::Key" do
     Bitcoin.network = :testnet3
     Bitcoin::Key.new("e3ff5d7e592669d0c1714f1496b260815edd0c3a00186e896dc7f36ede914dd2",
       nil, true).to_base58.should == "cVDu6aXUWHTM2vpztZW14BMnKkCcd5th6177VnCsa8XozoMyp73C"
-    Bitcoin.network = :bitcoin  end
+    Bitcoin.network = :bitcoin
+  end
 
   it "should import private key in compressed base58 format" do
     Bitcoin.network = :bitcoin
     key = Bitcoin::Key.from_base58("L2LusdhGSagfUVvNWrUuPDygn5mdAhxUDEANfABvBj36Twn1mKgQ")
     key.priv.should == "98e4483a197fb686fe9afb51389f329aabc67964b1d0e0a5340c962a0d63c44a"
     key.pub.should == "02e054ee811165ac294c992ff410067db6491228725fe09db2a415493c897973a8"
+    key.compressed.should == true
     key.addr.should == "1C7Ni4zuV3zfLs8T1S7s29wNAtRoDHHnpw"
     Bitcoin.network = :testnet3
     key = Bitcoin::Key.from_base58("cVDu6aXUWHTM2vpztZW14BMnKkCcd5th6177VnCsa8XozoMyp73C")
@@ -146,7 +150,7 @@ describe "Bitcoin::Key" do
     Bitcoin.network = :bitcoin
   end
 
-  it "should hanlde compressed and uncompressed pubkeys" do
+  it "should handle compressed and uncompressed pubkeys" do
     compressed   = "0351efb6e91a31221652105d032a2508275f374cea63939ad72f1b1e02f477da78"
     uncompressed = "0451efb6e91a31221652105d032a2508275f374cea63939ad72f1b1e02f477da787f71a2e8ac5aacedab47904d4bd42f636429e9ce069ebcb99f675aad31306a53"
     Bitcoin::Key.new(nil, compressed).compressed.should == true

--- a/spec/bitcoin/wallet/keygenerator_spec.rb
+++ b/spec/bitcoin/wallet/keygenerator_spec.rb
@@ -28,7 +28,10 @@ describe "Bitcoin::KeyGenerator" do
   it "should use given nonce" do
     g = KeyGenerator.new("foo", 2116)
     g.nonce.should == 2116
-    g.get_key(0).addr.should == '1GjyUrY3XcR4BvfgL8HqoAJbNDEgxSJdm1'
+    key = g.get_key(0)
+    key.addr.should == '1JvRdnShvscPtoP44VxPk5VaFBAo7ozRPb'
+    key.instance_eval { @pubkey_compressed = false }
+    key.addr.should == '1GjyUrY3XcR4BvfgL8HqoAJbNDEgxSJdm1'
   end
 
   it "should check nonce if given" do
@@ -38,10 +41,10 @@ describe "Bitcoin::KeyGenerator" do
   it "should use different target if given" do
     g = KeyGenerator.new("foo", nil, @target)
     g.nonce.should == 127
-    g.get_key(0).addr.should == "13E68pPJyGycgQ4ZmV45xV9r9XEeyWqZdp"
+    g.get_key(0).addr.should == "1KLBACvBnz9BTdBnuJmNuQpKQrsi55sstj"
     g = KeyGenerator.new("bar", nil, @target)
     g.nonce.should == 40
-    g.get_key(0).addr.should == "12iQpWRRQBmWcHYkTZkpDFrykzc9xn5kAU"
+    g.get_key(0).addr.should == "14T4deW5BGVA7wXpR3eoU9U8xprUJepxcy"
   end
 
   it "should find keys" do

--- a/spec/bitcoin/wallet/keystore_spec.rb
+++ b/spec/bitcoin/wallet/keystore_spec.rb
@@ -173,7 +173,7 @@ describe "Bitcoin::Wallet::DeterministicKeyStore" do
   end
 
   it "should get key" do
-    @ks.key('1KDUUSjPJkKwVEJsfpxEzBAf7iEbmqUwUu').priv.should ==
+    @ks.key('1GKjKQemNRhxL1ChTRFJNLZCXeCDxut2d7').priv.should ==
       '7f27bb0ca02e558c4b4b4e267417437adac01403e0d0bb9b07797d1dbb1adfd1'
   end
 
@@ -183,8 +183,8 @@ describe "Bitcoin::Wallet::DeterministicKeyStore" do
   end
 
   it "should export key" do
-    @ks.export('1KDUUSjPJkKwVEJsfpxEzBAf7iEbmqUwUu').should ==
-      '5JnHbCHicVj2Wgd2KgNPU7dQ6te55GzHjc4PH9cQDFUjeepYSHX'
+    @ks.export('1GKjKQemNRhxL1ChTRFJNLZCXeCDxut2d7').should ==
+      'L1UtDvpnffnVg1szqSmQAgFexzvcysZrs3jwLH1FT4uREpZqcXaR'
   end
 
 end


### PR DESCRIPTION
The Bitcoin::Key class supports compressed pubkeys since ages, but the default is still uncompressed. Let's save the blockchain some space, and ourselves some tx fees, and change that.
