### PR TITLE
to_multisig_script_sig Shouldn't append SIGHASH

### DIFF
--- a/lib/bitcoin/script.rb
+++ b/lib/bitcoin/script.rb
@@ -687,7 +687,6 @@ class Bitcoin::Script
   # returns a raw binary script sig of the form:
   #  OP_0 <sig> [<sig> ...]
   def self.to_multisig_script_sig(*sigs)
-    sigs.map!{|s| s + "\x01" }
     from_string("0 #{sigs.map{|s|s.unpack('H*')[0]}.join(' ')}").raw
   end
 


### PR DESCRIPTION
Added in b36dd97d, it seems like this violates principle of least surprise (and broke all of my code). If this method is going to append SIGHASH bytes, it should also offer some way of changing the type, and not assume SIGHASHALL. Though, my vote is that it joins the sigs as they are passed in.
