### PR TITLE
Remove 'rescue Exception'

### DIFF
--- a/examples/bbe_verify_tx.rb
+++ b/examples/bbe_verify_tx.rb
@@ -23,7 +23,7 @@ def get_tx(hash)
   end
   json = open(url).read
   Bitcoin::Protocol::Tx.from_json(json)
-rescue Exception
+rescue
   nil
 end
 

--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -329,7 +329,7 @@ module Bitcoin
       raise "malformed signature"       unless signature.bytesize == 65
       pubkey = Bitcoin::OpenSSL_EC.recover_compact(hash, signature)
       pubkey_to_address(pubkey) == address if pubkey
-    rescue Exception => ex
+    rescue => ex
       p [ex.message, ex.backtrace]; false
     end
 

--- a/lib/bitcoin/network/command_handler.rb
+++ b/lib/bitcoin/network/command_handler.rb
@@ -58,7 +58,7 @@ class Bitcoin::Network::CommandHandler < EM::Connection
         p $!; puts *$@
       end
     end
-  rescue Exception
+  rescue
     p $!; puts *$@
   end
 
@@ -74,7 +74,7 @@ class Bitcoin::Network::CommandHandler < EM::Connection
   # receive only transactions with 6 confirmations.
   # You can send the last block/tx/output you know about, and it will also send you
   # all the objects you're missing.
-  # 
+  #
   # Receive new blocks:
   #  bitcoin_node monitor block
   # Receive blocks since block 123, and new ones as they come in:
@@ -93,7 +93,7 @@ class Bitcoin::Network::CommandHandler < EM::Connection
   #  bitcoin_node monitor connection"
   # Combine multiple channels:
   #  bitcoin_node monitor "block tx tx_1 tx_6 connection"
-  # 
+  #
   # NOTE: When a new block is found, it might include transactions that we
   # didn't previously receive as unconfirmed. To make sure you receive all
   # transactions, also subscribe to the tx_1 channel.

--- a/lib/bitcoin/network/connection_handler.rb
+++ b/lib/bitcoin/network/connection_handler.rb
@@ -41,7 +41,7 @@ module Bitcoin::Network
       @latency_ms = nil
       @lock = Monitor.new
       @last_getblocks = []  # the last few getblocks messages received
-    rescue Exception
+    rescue
       log.fatal { "Error in #initialize" }
       p $!; puts $@; exit
     end
@@ -51,7 +51,7 @@ module Bitcoin::Network
       if incoming?
         begin_handshake
       end
-    rescue Exception
+    rescue
       log.fatal { "Error in #post_init" }
       p $!; puts *$@
     end
@@ -60,7 +60,7 @@ module Bitcoin::Network
     def connection_completed
       @connection_completed = true
       begin_handshake
-    rescue Exception
+    rescue
       log.fatal { "Error in #connection_completed" }
       p $!; puts *$@
     end
@@ -92,7 +92,7 @@ module Bitcoin::Network
       @node.connections << self
       @state = :handshake
       send_version
-    rescue Exception
+    rescue
       log.fatal { "Error in #begin_handshake" }
       p $!; puts *$@
     end
@@ -312,7 +312,7 @@ module Bitcoin::Network
         send_data(Protocol.ping_pkt(@ping_nonce))
       else
         # set latency to 5 seconds, terrible but this version should be obsolete now
-        @latency_ms = (5*1000) 
+        @latency_ms = (5*1000)
         log.debug { "<< ping" }
         send_data(Protocol.ping_pkt)
       end

--- a/lib/bitcoin/script.rb
+++ b/lib/bitcoin/script.rb
@@ -225,7 +225,7 @@ class Bitcoin::Script
       end
     end
     chunks
-  rescue Exception => ex
+  rescue => ex
     # bail out! #run returns false but serialization roundtrips still create the right payload.
     chunks.pop if ex.message.include?("invalid OP_PUSHDATA")
     @parse_invalid = true


### PR DESCRIPTION
I can't see any cases where root exception will be thrown, everything should inherit from `StandardError`.
