### PR TITLE
Fix exception when parsing from headers only

### DIFF
--- a/lib/bitcoin/protocol/block.rb
+++ b/lib/bitcoin/protocol/block.rb
@@ -56,7 +56,7 @@ module Bitcoin
       end
 
       # create block from raw binary +data+
-      def initialize(data)
+      def initialize(data=nil)
         @tx = []
         parse_data_from_io(data) if data
       end


### PR DESCRIPTION
I was getting an argument exception because `Block.new` was expecting an argument: https://github.com/lian/bitcoin-ruby/blob/master/lib/bitcoin/protocol/parser.rb#L63

This fixes the problem, but I think the API would be a bit cleaner if we could do `Block.new(data, header_only: true)`
