### PR TITLE
Cleanup address and script types

### DIFF
--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -59,9 +59,6 @@ module Bitcoin
 
   module Util
 
-    def address_version; Bitcoin.network[:address_version]; end
-    def p2sh_version; Bitcoin.network[:p2sh_version]; end
-
     # hash160 is a 20 bytes (160bits) rmd610-sha256 hexdigest.
     def hash160(hex)
       bytes = [hex].pack("H*")
@@ -87,7 +84,7 @@ module Bitcoin
     def valid_address?(address)
       hex = decode_base58(address) rescue nil
       return false unless hex && hex.bytesize == 50
-      return false unless [address_version, p2sh_version].include?(hex[0...2])
+      return false unless network[:address_versions].find{|t, b| b == hex[0...2] }
       address_checksum?(address)
     end
 
@@ -99,45 +96,54 @@ module Bitcoin
       false
     end
 
-    # get hash160 for given +address+. returns nil if address is invalid.
-    def hash160_from_address(address)
-      return nil  unless valid_address?(address)
-      decode_base58(address)[2...42]
-    end
-
-    # get type of given +address+.
-    def address_type(address)
-      return nil unless valid_address?(address)
-      case decode_base58(address)[0...2]
-      when address_version; :hash160
-      when p2sh_version;    :p2sh
-      end
-    end
-
-    def sha256(hex)
-      Digest::SHA256.hexdigest([hex].pack("H*"))
-    end
-
-    def hash160_to_address(hex)
-      encode_address hex, address_version
-    end
-
-    def hash160_to_p2sh_address(hex)
-      encode_address hex, p2sh_version
-    end
-
-    def encode_address(hex, version)
-      hex = version + hex
+    # Encode given +hex+ into bitcoin address of given +type+.
+    def encode_address(hex, type = :pubkey_hash)
+      hex = network[:address_versions][type] + hex
       encode_base58(hex + checksum(hex))
     end
 
-    def pubkey_to_address(pubkey)
-      hash160_to_address( hash160(pubkey) )
+    # Decode hash160 and type from given +address+. Returns nil when the checksum
+    # or type are invalid.
+    def decode_address(address)
+      return nil  unless valid_address?(address)
+      data = decode_base58(address)
+      return data[2...42], network[:address_versions].find{|t, b| data[0...2] == b}[0]
+    rescue
+      nil
     end
 
+    # Get hash160 of the given +address+. Note that in order to recreate the address from
+    # the hash160, you also need the type. See #decode_address.
+    def hash160_from_address(address)
+      decode_address(address)[0]  rescue nil
+    end
+
+    # Get type of the given +address+. See #decode_address.
+    def address_type(address)
+      decode_address(address)[1] rescue nil
+    end
+
+    # Encode hash160 given as +hex+ into bitcoin address of given +type+ (defaults to :hash160).
+    def hash160_to_address(hex, type = :pubkey_hash)
+      encode_address hex, type
+    end
+
+    # Encode hash160 given as +hex+ into bitcoin address of :p2sh type.
+    def hash160_to_p2sh_address(hex)
+      encode_address hex, :script_hash
+    end
+
+    # Encode hash160 of given +pubkey+ (or any +data+) into bitcoin address of given +type+.
+    def pubkey_to_address(pubkey, type = :pubkey_hash)
+      encode_address( hash160(pubkey), type )
+    end
+    alias :data_to_address :pubkey_to_address
+
+    # Create a p2sh script for given multisig parameters and return the p2sh address
+    # as well as the raw script.
     def pubkeys_to_p2sh_multisig_address(m, *pubkeys)
-      redeem_script = Bitcoin::Script.to_p2sh_multisig_script(m, *pubkeys).last
-      return Bitcoin.hash160_to_p2sh_address(Bitcoin.hash160(redeem_script.hth)), redeem_script
+      redeem_script = Script.to_p2sh_multisig_script(m, *pubkeys).last
+      return data_to_address(redeem_script.hth, :script_hash), redeem_script
     end
 
     def int_to_base58(int_val, leading_zero_bytes=0)
@@ -566,8 +572,7 @@ module Bitcoin
     bitcoin: {
       project: :bitcoin,
       magic_head: "\xF9\xBE\xB4\xD9",
-      address_version: "00",
-      p2sh_version: "05",
+      address_versions: { pubkey_hash: "00", script_hash: "05" },
       privkey_version: "80",
       default_port: 8333,
       protocol_version: 70001,
@@ -618,8 +623,7 @@ module Bitcoin
 
   NETWORKS[:testnet] = NETWORKS[:bitcoin].merge({
       magic_head: "\xFA\xBF\xB5\xDA",
-      address_version: "6f",
-      p2sh_version: "c4",
+      address_versions: { pubkey_hash: "6f", script_hash: "c4" },
       privkey_version: "ef",
       default_port: 18333,
       dns_seeds: [ ],
@@ -659,8 +663,7 @@ module Bitcoin
   NETWORKS[:litecoin] = NETWORKS[:bitcoin].merge({
       project: :litecoin,
       magic_head: "\xfb\xc0\xb6\xdb",
-      address_version: "30",
-      p2sh_version: "05",
+      address_versions: { pubkey_hash: "30", script_hash: "05" },
       privkey_version: "b0",
       default_port: 9333,
       protocol_version: 70002,
@@ -707,8 +710,7 @@ module Bitcoin
 
   NETWORKS[:litecoin_testnet] = NETWORKS[:litecoin].merge({
       magic_head: "\xfc\xc1\xb7\xdc",
-      address_version: "6f",
-      p2sh_version: "c4",
+      address_versions: { pubkey_hash: "6f", script_hash: "c4" },
       privkey_version: "ef",
       default_port: 19333,
       dns_seeds: [
@@ -727,8 +729,7 @@ module Bitcoin
   NETWORKS[:dogecoin] = NETWORKS[:litecoin].merge({
       project: :dogecoin,
       magic_head: "\xc0\xc0\xc0\xc0",
-      address_version: "1e",
-      p2sh_version: "16",
+      address_versions: { pubkey_hash: "1e", script_hash: "16" },
       privkey_version: "9e",
       default_port: 22556,
       protocol_version: 70003,
@@ -784,8 +785,7 @@ module Bitcoin
   NETWORKS[:dogecoin_testnet] = NETWORKS[:dogecoin].merge({
       project: :dogecoin,
       magic_head: "\xfc\xc1\xb7\xdc",
-      address_version: "71",
-      p2sh_version: "c4",
+      address_versions: { pubkey_hash: "71", script_hash: "c4" },
       privkey_version: "f1",
       default_port: 44556,
       protocol_version: 70003,
@@ -827,7 +827,7 @@ module Bitcoin
   NETWORKS[:namecoin] = NETWORKS[:bitcoin].merge({
       project: :namecoin,
       magic_head: "\xF9\xBE\xB4\xFE",
-      address_version: "34",
+      address_versions: { pubkey_hash: "34" },
       default_port: 8334,
       protocol_version: 35000,
       min_tx_fee: 50_000,

--- a/lib/bitcoin/contracthash.rb
+++ b/lib/bitcoin/contracthash.rb
@@ -60,8 +60,8 @@ module Bitcoin
       nonce = nonce_hex ? [nonce_hex].pack("H32") : SecureRandom.random_bytes(16)
       if Bitcoin.valid_address?(address_or_ascii)
         address_type = case Bitcoin.address_type(address_or_ascii)
-                       when :hash160;  'P2PH'
-                       when :p2sh;     'P2SH'
+                       when :pubkey_hash;  'P2PH'
+                       when :script_hash;     'P2SH'
                        else
                          raise "unsupported address type #{address_type}"
                        end

--- a/lib/bitcoin/namecoin.rb
+++ b/lib/bitcoin/namecoin.rb
@@ -48,10 +48,10 @@ module Bitcoin::Namecoin
           if is_name_new?;            :name_new
           elsif is_name_firstupdate?; :name_firstupdate
           elsif is_name_update?;      :name_update
-          elsif is_hash160?;          :hash160
+          elsif is_pubkey_hash?;      :pubkey_hash
           elsif is_pubkey?;           :pubkey
           elsif is_multisig?;         :multisig
-          elsif is_p2sh?;             :p2sh
+          elsif is_script_hash?;      :script_hash
           else;                       :unknown
           end
         end

--- a/lib/bitcoin/script.rb
+++ b/lib/bitcoin/script.rb
@@ -519,7 +519,7 @@ class Bitcoin::Script
   end
 
   # is this a :script_hash (pay-to-script-hash/p2sh) script?
-  def is_pay_to_script_hash?
+  def is_script_hash?
     return false  if @inner_p2sh
     if @previous_output_script
       chunks = Bitcoin::Script.new(@previous_output_script).chunks
@@ -536,35 +536,37 @@ class Bitcoin::Script
       (@chunks.size > 3 ? pay_to_script_hash(nil, nil, :check) : true)
     end
   end
-  alias :is_p2sh? :is_pay_to_script_hash?
+  alias :is_p2sh? :is_script_hash?
+  alias :is_pay_to_script_hash? :is_script_hash?
 
   # check if script is in one of the recognized standard formats
   def is_standard?
-    is_pubkey? || is_hash160? || is_multisig? || is_p2sh?  || is_op_return?
+    is_pubkey? || is_pubkey_hash? || is_multisig? || is_script_hash?  || is_op_return?
   end
 
-  # is this a pubkey script
+  # is this a :pubkey script?
   def is_pubkey?
     return false if @chunks.size != 2
     (@chunks[1] == OP_CHECKSIG) && @chunks[0] && (@chunks[0].is_a?(String)) && @chunks[0] != OP_RETURN
   end
   alias :is_send_to_ip? :is_pubkey?
 
-  # is this a hash160 (address) script
-  def is_hash160?
+  # is this a :pubkey_hash (hash160, regular address) script?
+  def is_pubkey_hash?
     return false  if @chunks.size != 5
     (@chunks[0..1] + @chunks[-2..-1]) ==
       [OP_DUP, OP_HASH160, OP_EQUALVERIFY, OP_CHECKSIG] &&
       @chunks[2].is_a?(String) && @chunks[2].bytesize == 20
   end
+  alias :is_hash160? :is_pubkey_hash?
 
-  # is this a multisig script
+  # is this a :multisig script?
   def is_multisig?
     return false  if @chunks.size < 4 || !@chunks[-2].is_a?(Fixnum)
     @chunks[-1] == OP_CHECKMULTISIG and get_multisig_pubkeys.all?{|c| c.is_a?(String) }
   end
 
-  # is this an op_return script
+  # is this an :op_return script?
   def is_op_return?
     @chunks[0] == OP_RETURN && @chunks.size <= 2
   end
@@ -617,12 +619,12 @@ class Bitcoin::Script
     false
   end
 
-  # get type of this tx
+  # get type of this script
   def type
-    if is_hash160?;     :hash160
+    if is_pubkey_hash?; :pubkey_hash
     elsif is_pubkey?;   :pubkey
     elsif is_multisig?; :multisig
-    elsif is_p2sh?;     :p2sh
+    elsif is_p2sh?;     :script_hash
     elsif is_op_return?;:op_return
     else;               :unknown
     end
@@ -641,8 +643,8 @@ class Bitcoin::Script
 
   # get the hash160 for this hash160 or pubkey script
   def get_hash160
-    return @chunks[2..-3][0].unpack("H*")[0]  if is_hash160?
-    return @chunks[-2].unpack("H*")[0]        if is_p2sh?
+    return @chunks[2..-3][0].unpack("H*")[0]  if is_pubkey_hash?
+    return @chunks[-2].unpack("H*")[0]        if is_script_hash?
     return Bitcoin.hash160(get_pubkey)        if is_pubkey?
   end
 
@@ -667,7 +669,7 @@ class Bitcoin::Script
   end
 
   def get_p2sh_address
-    Bitcoin.hash160_to_p2sh_address(get_hash160)
+    Bitcoin.hash160_to_address(get_hash160, :script_hash)
   end
 
   # get the data possibly included in an OP_RETURN script
@@ -679,9 +681,9 @@ class Bitcoin::Script
   # get all addresses this script corresponds to (if possible)
   def get_addresses
     return [get_pubkey_address]    if is_pubkey?
-    return [get_hash160_address]   if is_hash160?
+    return [get_hash160_address]   if is_pubkey_hash?
     return get_multisig_addresses  if is_multisig?
-    return [get_p2sh_address]      if is_p2sh?
+    return [get_p2sh_address]      if is_script_hash?
     []
   end
 
@@ -691,35 +693,37 @@ class Bitcoin::Script
     addrs.is_a?(Array) ? addrs[0] : addrs
   end
 
-  # generate pubkey tx script for given +pubkey+. returns a raw binary script of the form:
+  # generate :pubkey output script for given +pubkey+. returns a raw binary script of the form:
   #  <pubkey> OP_CHECKSIG
   def self.to_pubkey_script(pubkey)
     pack_pushdata([pubkey].pack("H*")) + [ OP_CHECKSIG ].pack("C")
   end
 
-  # generate hash160 tx for given +address+. returns a raw binary script of the form:
+  # generate :pubkey_hash output script for given +address+. returns a raw binary script of the form:
   #  OP_DUP OP_HASH160 <hash160> OP_EQUALVERIFY OP_CHECKSIG
-  def self.to_hash160_script(hash160)
+  def self.to_pubkey_hash_script(hash160)
     return nil  unless hash160
     #  DUP   HASH160  length  hash160    EQUALVERIFY  CHECKSIG
     [ ["76", "a9",    "14",   hash160,   "88",        "ac"].join ].pack("H*")
   end
+  def self.to_hash160_script(h); to_pubkey_hash_script(h); end
 
-  # generate p2sh output script for given +p2sh+ hash160. returns a raw binary script of the form:
+  # generate :script_hash output script for given +p2sh+ hash160. returns a raw binary script of the form:
   #  OP_HASH160 <p2sh> OP_EQUAL
-  def self.to_p2sh_script(p2sh)
+  def self.to_script_hash_script(p2sh)
     return nil  unless p2sh
     # HASH160  length  hash  EQUAL
     [ ["a9",   "14",   p2sh, "87"].join ].pack("H*")
   end
+  def self.to_p2sh_script(h); to_script_hash_script(h); end
 
-  # generate hash160 or p2sh output script, depending on the type of the given +address+.
+  # generate :pubkey_hash or :script_hash output script, depending on the type of the given +address+.
   # see #to_hash160_script and #to_p2sh_script.
   def self.to_address_script(address)
     hash160 = Bitcoin.hash160_from_address(address)
     case Bitcoin.address_type(address)
-    when :hash160; to_hash160_script(hash160)
-    when :p2sh;    to_p2sh_script(hash160)
+    when :pubkey_hash; to_pubkey_hash_script(hash160)
+    when :script_hash; to_script_hash_script(hash160)
     end
   end
 

--- a/lib/bitcoin/storage/storage.rb
+++ b/lib/bitcoin/storage/storage.rb
@@ -49,13 +49,13 @@ module Bitcoin::Storage
       ORPHAN = 2
 
       # possible script types
-      SCRIPT_TYPES = [:unknown, :pubkey, :hash160, :multisig, :p2sh, :op_return]
+      SCRIPT_TYPES = [:unknown, :pubkey, :pubkey_hash, :multisig, :script_hash, :op_return]
       if Bitcoin.namecoin?
         [:name_new, :name_firstupdate, :name_update].each {|n| SCRIPT_TYPES << n }
       end
 
       # possible address types
-      ADDRESS_TYPES = [:hash160, :p2sh]
+      ADDRESS_TYPES = [:pubkey_hash, :script_hash]
 
       DEFAULT_CONFIG = {}
 
@@ -366,7 +366,7 @@ module Bitcoin::Storage
         if Bitcoin.valid_address?(hash160_or_addr)
           txouts = get_txouts_for_address(hash160_or_addr)
         else
-          txouts = get_txouts_for_hash160(hash160_or_addr, :hash160, unconfirmed)
+          txouts = get_txouts_for_hash160(hash160_or_addr, :pubkey_hash, unconfirmed)
         end
         unspent = txouts.select {|o| o.get_next_in.nil?}
         unspent.map(&:value).inject {|a,b| a+=b; a} || 0

--- a/spec/bitcoin/bitcoin_spec.rb
+++ b/spec/bitcoin/bitcoin_spec.rb
@@ -180,12 +180,12 @@ describe 'Bitcoin Address/Hash160/PubKey' do
 
   it '#address_type' do
     Bitcoin.network = :testnet
-    Bitcoin.address_type("2MyLngQnhzjzatKsB7XfHYoP9e2XUXSiBMM").should == :p2sh
-    Bitcoin.address_type("mpXwg4jMtRhuSpVq4xS3HFHmCmWp9NyGKt").should == :hash160
+    Bitcoin.address_type("2MyLngQnhzjzatKsB7XfHYoP9e2XUXSiBMM").should == :script_hash
+    Bitcoin.address_type("mpXwg4jMtRhuSpVq4xS3HFHmCmWp9NyGKt").should == :pubkey_hash
     Bitcoin.address_type("1D3KpY5kXnYhTbdCbZ9kXb2ZY7ZapD85cW").should == nil
     Bitcoin.network = :bitcoin
-    Bitcoin.address_type("3CkxTG25waxsmd13FFgRChPuGYba3ar36B").should == :p2sh
-    Bitcoin.address_type("1D3KpY5kXnYhTbdCbZ9kXb2ZY7ZapD85cW").should == :hash160
+    Bitcoin.address_type("3CkxTG25waxsmd13FFgRChPuGYba3ar36B").should == :script_hash
+    Bitcoin.address_type("1D3KpY5kXnYhTbdCbZ9kXb2ZY7ZapD85cW").should == :pubkey_hash
     Bitcoin.address_type("mpXwg4jMtRhuSpVq4xS3HFHmCmWp9NyGKt").should == nil
   end
 

--- a/spec/bitcoin/builder_spec.rb
+++ b/spec/bitcoin/builder_spec.rb
@@ -68,7 +68,7 @@ describe "Bitcoin::Builder" do
 
     tx.out[0].value.should == 123
     script = Bitcoin::Script.new(tx.out[0].pk_script)
-    script.type.should == :hash160
+    script.type.should == :pubkey_hash
     script.get_address.should == @keys[1].addr
 
     tx.verify_input_signature(0, block.tx[0]).should == true

--- a/spec/bitcoin/network_spec.rb
+++ b/spec/bitcoin/network_spec.rb
@@ -8,7 +8,7 @@ describe 'Bitcoin::network' do
     Bitcoin.network = :bitcoin
     net = Bitcoin::network
     net[:magic_head].should == "\xF9\xBE\xB4\xD9"
-    net[:address_version].should == "00"
+    net[:address_versions][:pubkey_hash].should == "00"
     net[:genesis_hash].should == "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
   end
 

--- a/spec/bitcoin/script/opcodes_spec.rb
+++ b/spec/bitcoin/script/opcodes_spec.rb
@@ -671,7 +671,7 @@ describe "Bitcoin::Script OPCODES" do
 
     address = "3CkxTG25waxsmd13FFgRChPuGYba3ar36B"
     script = Bitcoin::Script.new(Bitcoin::Script.to_address_script(address))
-    script.type.should == :p2sh
+    script.type.should == :script_hash
 
     inner_script = Bitcoin::Script.from_string("0 OP_NOT").raw.unpack("H*")[0]
     script_hash = Bitcoin.hash160(inner_script)

--- a/spec/bitcoin/script/script_spec.rb
+++ b/spec/bitcoin/script/script_spec.rb
@@ -285,10 +285,10 @@ describe 'Bitcoin::Script' do
     it "#type" do
       Script.new(SCRIPT[0]).type.should == :pubkey
       Script.new(SCRIPT[1]).type.should == :unknown
-      Script.new(SCRIPT[2]).type.should == :hash160
+      Script.new(SCRIPT[2]).type.should == :pubkey_hash
       Script.new(SCRIPT[3]).type.should == :multisig
       Script.new(SCRIPT[4]).type.should == :multisig
-      Script.new(SCRIPT[5]).type.should == :p2sh
+      Script.new(SCRIPT[5]).type.should == :script_hash
       Script.new(SCRIPT[6]).type.should == :op_return
       Script.from_string("OP_RETURN OP_CHECKSIG").type.should == :op_return
       Script.from_string("OP_RETURN dead beef").type.should == :unknown

--- a/spec/bitcoin/spec_helper.rb
+++ b/spec/bitcoin/spec_helper.rb
@@ -80,27 +80,13 @@ end
 
 Bitcoin::network = :bitcoin
 
-Bitcoin::NETWORKS[:spec] = {
-  :project => :bitcoin,
-  :magic_head => "spec",
-  :address_version => "6f",
-  :p2sh_version => "c4",
-  :privkey_version => "ef",
-  :default_port => 48333,
-  :protocol_version => 70001,
-  :max_money => 21_000_000 * 100_000_000,
-  :dns_seeds => [],
-  :genesis_hash => "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
-  :proof_of_work_limit => 553713663,
-  :alert_pubkeys => [],
-  :known_nodes => [],
-  :checkpoints => {},
-  :min_tx_fee => 10_000,
-  :min_relay_tx_fee => 10_000,
-  :free_tx_bytes => 1_000,
-  :dust => 1_000_000,
-  :per_dust_fee => false,
-}
+Bitcoin::NETWORKS[:spec] = Bitcoin::NETWORKS[:regtest].merge({
+  magic_head: "spec",
+  default_port: 48333,
+  proof_of_work_limit: 553713663,
+  genesis_hash: "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
+  alert_pubkeys: [],
+})
 
 begin
   require 'bacon'

--- a/spec/bitcoin/storage/storage_spec.rb
+++ b/spec/bitcoin/storage/storage_spec.rb
@@ -228,7 +228,7 @@ Bitcoin::network = :testnet
           @store.store_tx(@tx, false)
           keys.each do |key|
             hash160 = Bitcoin.hash160(key.pub)
-            txouts = @store.get_txouts_for_hash160(hash160, :hash160, true)
+            txouts = @store.get_txouts_for_hash160(hash160, :pubkey_hash, true)
             txouts.size.should == 1
             txouts[0].pk_script.should == txout.pk_script
           end
@@ -236,7 +236,7 @@ Bitcoin::network = :testnet
 
         it "should index output script type" do
           @store.store_tx(@tx, false)
-          @store.get_tx(@tx.hash).out.first.type.should == :hash160
+          @store.get_tx(@tx.hash).out.first.type.should == :pubkey_hash
         end
 
       end
@@ -265,7 +265,7 @@ Bitcoin::network = :testnet
       end
 
       it "should get txouts for hash160" do
-        @store.get_txouts_for_hash160(@key2.hash160, :hash160, true)
+        @store.get_txouts_for_hash160(@key2.hash160, :pubkey_hash, true)
           .should == [@block.tx[1].out[0]]
       end
 
@@ -301,7 +301,7 @@ Bitcoin::network = :testnet
           t.input {|i| i.prev_out(@block.tx[1], 0); i.signature_key(@key2) }
           t.output do |o|
             o.value 10
-            o.to @key2.hash160, :p2sh
+            o.to @key2.hash160, :script_hash
           end
           t.output do |o|
             o.value 10
@@ -312,7 +312,7 @@ Bitcoin::network = :testnet
 
         @store.store_block(block)
 
-        p2sh_address = Bitcoin.hash160_to_p2sh_address(@key2.hash160)
+        p2sh_address = Bitcoin.hash160_to_address(@key2.hash160, :script_hash)
         o1 = @store.get_unspent_txouts_for_address(@key2.addr)
         o2 = @store.get_unspent_txouts_for_address(p2sh_address)
 


### PR DESCRIPTION
this makes for consistent naming of the address/script types everywhere,
gives us some more flexibility to introduce new types,
makes #encode/decode_address more generic and
highlights the importance of carrying the address type along the hash160,
while still preserving the old APIs for compatibility

only change is the return value of Script#type
