### PR TITLE
Handle empty merkle branches

### DIFF
--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -277,10 +277,12 @@ module Bitcoin
 
     # get merkle root from +branch+ and +target+.
     def mrkl_branch_root(branch, target, idx)
-      branch.map do |hash|
+      branch.each do |hash|
         a, b = *( idx & 1 == 0 ? [target, hash] : [hash, target] )
-        idx >>= 1; target = bitcoin_mrkl( a, b )
-      end.last
+        idx >>= 1;
+	target = bitcoin_mrkl( a, b )
+      end
+      target
     end
 
     def sign_data(key, data)

--- a/spec/bitcoin/bitcoin_spec.rb
+++ b/spec/bitcoin/bitcoin_spec.rb
@@ -318,6 +318,13 @@ describe 'Bitcoin Address/Hash160/PubKey' do
     Bitcoin.hash_mrkl_tree(["aa", "bb", "cc"]).last.should !=
       Bitcoin.hash_mrkl_tree(["aa", "bb", "cc", "cc"]).last
   end
+  
+  it 'return a value even if a merkle branch is empty' do
+    branch = []
+    mrkl_index = 0
+    target = "089b911f5e471c0e1800f3384281ebec5b372fbb6f358790a92747ade271ccdf"
+    Bitcoin.mrkl_branch_root(branch.map(&:hth), target, mrkl_index).should == target
+  end
 
   it 'nonce compact bits to bignum hex' do
     Bitcoin.decode_compact_bits( "1b00b5ac".to_i(16) ).index(/[^0]/).should == 12


### PR DESCRIPTION
Corrects the issue where calculating merkle root from an empty merkle branch results in
nil. Now correctly returns the original hash.
