### PR TITLE
Add support for negative values in compact bytes (i.e. target bits)

### DIFF
--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -171,10 +171,16 @@ module Bitcoin
     # target compact bits (int) to bignum hex
     def decode_compact_bits(bits)
       bytes = Array.new(size=((bits >> 24) & 255), 0)
-      bytes[0] = (bits >> 16) & 255 if size >= 1
+      bytes[0] = (bits >> 16) & 0x7f if size >= 1
       bytes[1] = (bits >>  8) & 255 if size >= 2
       bytes[2] = (bits      ) & 255 if size >= 3
-      bytes.pack("C*").unpack("H*")[0].rjust(64, '0')
+      target = bytes.pack("C*").unpack("H*")[0].rjust(64, '0')
+      # Bit number 24 represents the sign
+      if (bits & 0x00800000) != 0
+        "-" + target
+      else
+        target
+      end
     end
 
     # target bignum hex to compact bits (int)

--- a/spec/bitcoin/bitcoin_spec.rb
+++ b/spec/bitcoin/bitcoin_spec.rb
@@ -327,6 +327,7 @@ describe 'Bitcoin Address/Hash160/PubKey' do
   end
 
   it 'nonce compact bits to bignum hex' do
+    Bitcoin.decode_compact_bits( "01fedcba".to_i(16) ).to_i(16).should == -0x7e
     Bitcoin.decode_compact_bits( "1b00b5ac".to_i(16) ).index(/[^0]/).should == 12
     Bitcoin.decode_compact_bits( "1b00b5ac".to_i(16) ).to_i(16).should ==
       "000000000000b5ac000000000000000000000000000000000000000000000000".to_i(16)


### PR DESCRIPTION
This adds handling of negative values in compact bytes.

The encoding method does not currently handle signed values, and tackling that is a significantly more complex task, so is left for a later patch.
