### PR TITLE
Prefer Resolv::DNS to subshell and regexps

### DIFF
--- a/lib/bitcoin/connection.rb
+++ b/lib/bitcoin/connection.rb
@@ -3,6 +3,7 @@
 require 'socket'
 require 'eventmachine'
 require 'bitcoin'
+require 'resolv'
 
 module Bitcoin
 
@@ -107,7 +108,7 @@ module Bitcoin
     def self.connect_random_from_dns(connections)
       seeds = Bitcoin.network[:dns_seeds]
       if seeds.any?
-        host = `nslookup #{seeds.sample}`.scan(/Address\: (.+)$/).flatten.sample
+        host = Resolv::DNS.new.getaddresses(seeds.sample).map {|a| a.to_s}.sample
         connect(host, Bitcoin::network[:default_port], connections)
       else
         raise "No DNS seeds available. Provide IP, configure seeds, or use different network."


### PR DESCRIPTION
Benefits
- support transparently both IPv6 and IPv4
- avoid spawning a child process
- friendlier to all Ruby VMs (especially jruby)
- less brittle when avoiding regexps

To test the change and check that it still connects and gets block chains properly run:

`ruby -Ilib lib/bitcoin/connection.rb`

To see Resolv::DNS in action run:

`irb> require 'resolv'; Resolv::DNS.new.getaddresses('seed.bitcoin.sipa.be').map(&:to_s)`
