### PR TITLE
Do not send "addr" twice to clients sending "verack"

### DIFF
--- a/lib/bitcoin/network/connection_handler.rb
+++ b/lib/bitcoin/network/connection_handler.rb
@@ -99,13 +99,12 @@ module Bitcoin::Network
 
     # complete handshake; set state, started time, notify listeners and add address to Node
     def complete_handshake
-      if @state == :handshake
-        log.debug { 'Handshake completed' }
-        @state = :connected
-        @started = Time.now
-        @node.push_notification(:connection, info.merge(type: :connected))
-        @node.addrs << addr
-      end
+      return unless @state == :handshake
+      log.debug { 'Handshake completed' }
+      @state = :connected
+      @started = Time.now
+      @node.push_notification(:connection, info.merge(type: :connected))
+      @node.addrs << addr
       send_data P::Addr.pkt(@node.addr)  if @node.config[:announce]
     end
 


### PR DESCRIPTION
In order to handle peers that omit the "verack" message
 #complete_handshake is called both on "version" and "verack" messages.

Until now this method triggered an "addr" command to the peer
unconditionally, though, so proper clients received the message twice.
