### PR TITLE
Generate low-S value DER signatures

### DIFF
--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -213,10 +213,6 @@ module Bitcoin
     end
 
     def bitcoin_elliptic_curve
-      # TODO: This can produce values which do not pass the low S-value check
-      # from BIP62. Need to look at how best to solve that (here or perhaps
-      # through OpenSSL) once Bitcoin Core implements that check in its own
-      # signature generation.
       ::OpenSSL::PKey::EC.new("secp256k1")
     end
 

--- a/lib/bitcoin/ffi/openssl.rb
+++ b/lib/bitcoin/ffi/openssl.rb
@@ -27,7 +27,7 @@ module OpenSSL_EC
   attach_function :BN_CTX_new, [], :pointer
   attach_function :BN_add, [:pointer, :pointer, :pointer], :int
   attach_function :BN_bin2bn, [:pointer, :int, :pointer], :pointer
-  attach_function :BN_bn2bin, [:pointer, :pointer], :void
+  attach_function :BN_bn2bin, [:pointer, :pointer], :int
   attach_function :BN_cmp, [:pointer, :pointer], :int
   attach_function :BN_copy, [:pointer, :pointer], :pointer
   attach_function :BN_dup, [:pointer], :pointer
@@ -38,6 +38,7 @@ module OpenSSL_EC
   attach_function :BN_mul_word, [:pointer, :int], :int
   attach_function :BN_new, [], :pointer
   attach_function :BN_rshift, [:pointer, :pointer, :int], :int
+  attach_function :BN_rshift1, [:pointer, :pointer], :int
   attach_function :BN_set_word, [:pointer, :int], :int
   attach_function :BN_sub, [:pointer, :pointer, :pointer], :int
   attach_function :EC_GROUP_get_curve_GFp, [:pointer, :pointer, :pointer, :pointer, :pointer], :int
@@ -230,6 +231,7 @@ module OpenSSL_EC
   def self.signature_to_low_s(signature)
     init_ffi_ssl
 
+    buf = FFI::MemoryPointer.new(:uint8, 34)
     temp = signature.unpack("C*")
     length_r = temp[3]
     length_s = temp[5+length_r]
@@ -238,24 +240,27 @@ module OpenSSL_EC
     # Calculate the lower s value
     s = BN_bin2bn(sig[6 + length_r], length_s, BN_new())
     eckey = EC_KEY_new_by_curve_name(NID_secp256k1)
-    group, order, ctx = EC_KEY_get0_group(eckey), BN_new(), BN_CTX_new()
-    # TODO: Should check the s value is over half the order of the curve, and
-    # return the original signature if not
-    EC_GROUP_get_order(group, order, ctx)
-    BN_sub(s, order, s)
+    group, order, halforder, ctx = EC_KEY_get0_group(eckey), BN_new(), BN_new(), BN_CTX_new()
 
+    EC_GROUP_get_order(group, order, ctx)
+    BN_rshift1(halforder, order)
+    if BN_cmp(order, halforder) > 0
+      BN_sub(s, order, s)
+    end
+
+    BN_free(halforder)
     BN_free(order)
     BN_CTX_free(ctx)
 
-    buf = FFI::MemoryPointer.new(:uint8, 32)
-    BN_bn2bin(s, buf)
+    length_s = BN_bn2bin(s, buf)
+    # p buf.read_string(length_s).unpack("H*")
 
     # Re-encode the signature in DER format
     sig = [0x30, 0, 0x02, length_r]
     sig.concat(temp.slice(4, length_r))
     sig << 0x02
-    sig << 32 # Revised s length
-    sig.concat(buf.read_string(32).unpack("C*"))
+    sig << length_s
+    sig.concat(buf.read_string(length_s).unpack("C*"))
     sig[1] = sig.size - 2
 
     BN_free(s)

--- a/lib/bitcoin/ffi/openssl.rb
+++ b/lib/bitcoin/ffi/openssl.rb
@@ -39,6 +39,7 @@ module OpenSSL_EC
   attach_function :BN_new, [], :pointer
   attach_function :BN_rshift, [:pointer, :pointer, :int], :int
   attach_function :BN_set_word, [:pointer, :int], :int
+  attach_function :BN_sub, [:pointer, :pointer, :pointer], :int
   attach_function :EC_GROUP_get_curve_GFp, [:pointer, :pointer, :pointer, :pointer, :pointer], :int
   attach_function :EC_GROUP_get_degree, [:pointer], :int
   attach_function :EC_GROUP_get_order, [:pointer, :pointer, :pointer], :int
@@ -221,6 +222,46 @@ module OpenSSL_EC
     EC_KEY_free(eckey)
 
     pub_hex
+  end
+
+  # Regenerate a DER-encoded signature such that the S-value complies with the BIP62
+  # specification.
+  #
+  def self.signature_to_low_s(signature)
+    init_ffi_ssl
+
+    temp = signature.unpack("C*")
+    length_r = temp[3]
+    length_s = temp[5+length_r]
+    sig = FFI::MemoryPointer.from_string(signature)
+
+    # Calculate the lower s value
+    s = BN_bin2bn(sig[6 + length_r], length_s, BN_new())
+    eckey = EC_KEY_new_by_curve_name(NID_secp256k1)
+    group, order, ctx = EC_KEY_get0_group(eckey), BN_new(), BN_CTX_new()
+    # TODO: Should check the s value is over half the order of the curve, and
+    # return the original signature if not
+    EC_GROUP_get_order(group, order, ctx)
+    BN_sub(s, order, s)
+
+    BN_free(order)
+    BN_CTX_free(ctx)
+
+    buf = FFI::MemoryPointer.new(:uint8, 32)
+    BN_bn2bin(s, buf)
+
+    # Re-encode the signature in DER format
+    sig = [0x30, 0, 0x02, length_r]
+    sig.concat(temp.slice(4, length_r))
+    sig << 0x02
+    sig << 32 # Revised s length
+    sig.concat(buf.read_string(32).unpack("C*"))
+    sig[1] = sig.size - 2
+
+    BN_free(s)
+    EC_KEY_free(eckey)
+
+    sig.pack("C*")
   end
 
   def self.sign_compact(hash, private_key, public_key_hex = nil, pubkey_compressed = nil)

--- a/lib/bitcoin/key.rb
+++ b/lib/bitcoin/key.rb
@@ -98,7 +98,12 @@ module Bitcoin
     #  key1 = Bitcoin::Key.generate
     #  sig = key1.sign("some data")
     def sign(data)
-      @key.dsa_sign_asn1(data)
+      sig = @key.dsa_sign_asn1(data)
+      if Script::is_low_der_signature?(sig)
+        sig
+      else
+        Bitcoin::OpenSSL_EC.signature_to_low_s(sig)
+      end
     end
 
     # Verify signature +sig+ for +data+.


### PR DESCRIPTION
Modified transaction signing to always generate low-S value DER signatures, which will comply with BIP62.