### PR TITLE
Parser error handling

### DIFF
--- a/lib/bitcoin/network/connection_handler.rb
+++ b/lib/bitcoin/network/connection_handler.rb
@@ -108,6 +108,11 @@ module Bitcoin::Network
       send_data P::Addr.pkt(@node.addr)  if @node.config[:announce]
     end
 
+    # error parsing a message, log as warning but otherwise ignore
+    def on_error(type, data)
+      log.warn { "error: #{type} (#{data})" }
+    end
+
     # received +inv_tx+ message for given +hash+.
     # add to inv_queue, unlesss maximum is reached
     def on_inv_transaction(hash)

--- a/lib/bitcoin/protocol/handler.rb
+++ b/lib/bitcoin/protocol/handler.rb
@@ -33,6 +33,10 @@ module Bitcoin
         puts block.to_json
       end
 
+      def on_error(message, payload)
+        p ['error', message, payload]
+      end
+
     end
 
   end

--- a/lib/bitcoin/protocol/parser.rb
+++ b/lib/bitcoin/protocol/parser.rb
@@ -48,11 +48,10 @@ module Bitcoin
         count, payload = Protocol.unpack_var_int(payload)
         payload.each_byte.each_slice(30){|i|
           begin
-            addr = Addr.new(i.pack("C*"))
+            @h.on_addr Addr.new(i.pack("C*"))
           rescue
             puts "Error parsing addr: #{i.inspect}"
           end
-          @h.on_addr( addr )
         }
       end
 

--- a/lib/bitcoin/protocol/parser.rb
+++ b/lib/bitcoin/protocol/parser.rb
@@ -9,50 +9,32 @@ module Bitcoin
       def initialize(handler=nil)
         @h = handler || Handler.new
         @buf = ""
-        @stats = {
-          'total_packets' => 0,
-          'total_bytes' => 0
-        }
+        @stats = { 'total_packets' => 0, 'total_bytes' => 0 }
       end
 
-      def log
-        @log ||= Bitcoin::Logger.create("parser")
-      end
+      def log; @log ||= Bitcoin::Logger.create("parser"); end
 
       # handles inv/getdata packets
-      #
       def parse_inv(payload, type=:put)
         count, payload = Protocol.unpack_var_int(payload)
-        payload.each_byte.each_slice(36){|i|
+        payload.each_byte.each_slice(36) do |i|
           hash = i[4..-1].reverse.pack("C32")
           case i[0]
           when 1
-            if type == :put
-              @h.on_inv_transaction(hash)
-            else
-              @h.on_get_transaction(hash)
-            end
+            type == :put ? @h.on_inv_transaction(hash) : @h.on_get_transaction(hash)
           when 2
-            if type == :put
-              @h.on_inv_block(hash)
-            else
-              @h.on_get_block(hash)
-            end
+            type == :put ? @h.on_inv_block(hash) : @h.on_get_block(hash)
           else
-            p ['parse_inv error', i]
+            @h.on_error :parse_inv, i.pack("C*")
           end
-        }
+        end
       end
 
       def parse_addr(payload)
         count, payload = Protocol.unpack_var_int(payload)
-        payload.each_byte.each_slice(30){|i|
-          begin
-            @h.on_addr Addr.new(i.pack("C*"))
-          rescue
-            puts "Error parsing addr: #{i.inspect}"
-          end
-        }
+        payload.each_byte.each_slice(30) do |i|
+          @h.on_addr(Addr.new(i.pack("C*"))) rescue @h.on_error(:addr, i.pack("C*"))
+        end
       end
 
       def parse_headers(payload)
@@ -94,7 +76,7 @@ module Bitcoin
         when 'mempool';  handle_mempool_request(payload)
         when 'notfound'; handle_notfound_reply(payload)
         else
-          p ['unknown-packet', command, payload]
+          @h.on_error :unknown_packet, [command, payload]
         end
       end
 
@@ -118,15 +100,15 @@ module Bitcoin
       def handle_notfound_reply(payload)
         return unless @h.respond_to?(:on_notfound)
         count, payload = Protocol.unpack_var_int(payload)
-        payload.each_byte.each_slice(36){|i|
+        payload.each_byte.each_slice(36) do |i|
           hash = i[4..-1].reverse.pack("C32")
           case i[0]
           when 1; @h.on_notfound(:tx, hash)
           when 2; @h.on_notfound(:block, hash)
           else
-            p ['handle_notfound_reply error', i, hash]
+            @h.on_error(:notfound, [i.pack("C*"), hash])
           end
-        }
+        end
       end
 
       def parse(buf)

--- a/spec/bitcoin/protocol/addr_spec.rb
+++ b/spec/bitcoin/protocol/addr_spec.rb
@@ -11,7 +11,8 @@ describe 'Bitcoin::Protocol::Parser (addr)' do
 
     class Addr_Handler < Bitcoin::Protocol::Handler
       attr_reader :addr
-      def on_addr(addr); (@addr ||= []) << addr; end
+      def initialize; @addr = []; end
+      def on_addr(addr); @addr << addr; end
     end
 
     parser = Bitcoin::Protocol::Parser.new( handler = Addr_Handler.new )
@@ -22,6 +23,13 @@ describe 'Bitcoin::Protocol::Parser (addr)' do
     handler.addr.map{|i| i.values }.should == [
       [1305992491, 1, "82.83.222.4", 8333]
     ]
+  end
+
+  it "doesn't call the handler if the address can't be parsed" do
+    pkt = ["01 00 00 00 00".split(" ").join].pack("H*")
+    parser = Bitcoin::Protocol::Parser.new( handler = Addr_Handler.new )
+    parser.parse_addr(pkt).should == nil
+    handler.addr.should == []
   end
 
 end
@@ -69,4 +77,5 @@ describe 'Bitcoin::Protocol::Addr' do
     Bitcoin::Protocol::Addr.pkt(addr).should ==
       Bitcoin::Protocol.pkt("addr", "\x01" + addr.to_payload)
   end
+
 end

--- a/spec/bitcoin/protocol/addr_spec.rb
+++ b/spec/bitcoin/protocol/addr_spec.rb
@@ -10,9 +10,9 @@ describe 'Bitcoin::Protocol::Parser (addr)' do
       .split(" ").join].pack("H*")
 
     class Addr_Handler < Bitcoin::Protocol::Handler
-      attr_reader :addr
-      def initialize; @addr = []; end
-      def on_addr(addr); @addr << addr; end
+      attr_reader :addr, :err
+      def on_addr(addr); (@addr ||= []) << addr; end
+      def on_error(*err); (@err ||= []) << err; end
     end
 
     parser = Bitcoin::Protocol::Parser.new( handler = Addr_Handler.new )
@@ -25,11 +25,12 @@ describe 'Bitcoin::Protocol::Parser (addr)' do
     ]
   end
 
-  it "doesn't call the handler if the address can't be parsed" do
+  it "parses broken address packet" do
     pkt = ["01 00 00 00 00".split(" ").join].pack("H*")
     parser = Bitcoin::Protocol::Parser.new( handler = Addr_Handler.new )
     parser.parse_addr(pkt).should == nil
-    handler.addr.should == []
+    handler.addr.should == nil
+    handler.err.should == [[:addr, pkt[1..-1]]]
   end
 
 end

--- a/spec/bitcoin/protocol/parser_spec.rb
+++ b/spec/bitcoin/protocol/parser_spec.rb
@@ -1,0 +1,37 @@
+# encoding: ascii-8bit
+
+require_relative '../spec_helper.rb'
+
+require 'minitest/mock'
+
+describe 'Bitcoin::Protocol::Parser' do
+
+  before { @handler = MiniTest::Mock.new }
+  after { @handler.verify }
+
+  it 'should call appropriate handler' do
+    pkt = [
+        "f9 be b4 d9", # magic head
+        "69 6e 76 00 00 00 00 00 00 00 00 00", # command ("inv")
+        "49 00 00 00", # message length
+        "11 ea 1c 91", # checksum
+
+        "02", # n hashes
+        "01 00 00 00", # type (1=tx)
+        "e0 41 c2 38 f7 32 1a 68 0a 34 06 bf fd 72 12 e3 d1 2c b5 12 2a 8c 0b 52 76 de 82 30 b1 00 7a 42",
+        "01 00 00 00", # type (1=tx)
+        "33 00 09 71 a9 70 7b 6c 6d 6e 77 aa 2e ac 43 f3 e5 67 84 cb 61 b2 35 fb 8d fe e0 86 8b 40 7c f3"
+      ].map{|s| s.split(" ")}.flatten.join.htb
+
+    @handler.expect(:on_inv_transaction, nil, [pkt[29..60].reverse])
+    @handler.expect(:on_inv_transaction, nil, [pkt[-32..-1].reverse])
+    Bitcoin::Protocol::Parser.new( @handler ).parse(pkt).should == ""
+  end
+
+  it 'should call error handler for unknown command' do
+    pkt = ("f9 be b4 d9 66 6f 6f" + " 00"*32).split(" ").join.htb
+    @handler.expect(:on_error, nil, [:unknown_packet, ["foo", "bar"]])
+    Bitcoin::Protocol::Parser.new( @handler ).process_pkt('foo', "bar").should == nil
+  end
+
+end

--- a/spec/bitcoin/protocol/parser_spec.rb
+++ b/spec/bitcoin/protocol/parser_spec.rb
@@ -1,16 +1,15 @@
 # encoding: ascii-8bit
 
 require_relative '../spec_helper.rb'
-
 require 'minitest/mock'
+
+include Bitcoin::Protocol
 
 describe 'Bitcoin::Protocol::Parser' do
 
-  before { @handler = MiniTest::Mock.new }
-  after { @handler.verify }
 
-  it 'should call appropriate handler' do
-    pkt = [
+  before {
+    @pkt= [
         "f9 be b4 d9", # magic head
         "69 6e 76 00 00 00 00 00 00 00 00 00", # command ("inv")
         "49 00 00 00", # message length
@@ -22,16 +21,30 @@ describe 'Bitcoin::Protocol::Parser' do
         "01 00 00 00", # type (1=tx)
         "33 00 09 71 a9 70 7b 6c 6d 6e 77 aa 2e ac 43 f3 e5 67 84 cb 61 b2 35 fb 8d fe e0 86 8b 40 7c f3"
       ].map{|s| s.split(" ")}.flatten.join.htb
+    @handler = MiniTest::Mock.new }
+  after { @handler.verify }
 
-    @handler.expect(:on_inv_transaction, nil, [pkt[29..60].reverse])
-    @handler.expect(:on_inv_transaction, nil, [pkt[-32..-1].reverse])
-    Bitcoin::Protocol::Parser.new( @handler ).parse(pkt).should == ""
+  it 'should call appropriate handler' do
+    @handler.expect(:on_inv_transaction, nil, [@pkt[29..60].reverse])
+    @handler.expect(:on_inv_transaction, nil, [@pkt[-32..-1].reverse])
+    Parser.new( @handler ).parse( @pkt ).should == ""
+  end
+
+  it 'should count total packets and bytes' do
+    parser = Parser.new
+    parser.parse @pkt
+    parser.stats.should == {"total_packets"=>1, "total_bytes"=>73, "total_errors" => 0, "inv"=>1}
   end
 
   it 'should call error handler for unknown command' do
-    pkt = ("f9 be b4 d9 66 6f 6f" + " 00"*32).split(" ").join.htb
     @handler.expect(:on_error, nil, [:unknown_packet, ["foo", "bar"]])
-    Bitcoin::Protocol::Parser.new( @handler ).process_pkt('foo', "bar").should == nil
+    Parser.new( @handler ).process_pkt('foo', "bar").should == nil
+  end
+
+  it 'should count total errors' do
+    parser = Parser.new
+    parser.process_pkt('foo', 'bar')
+    parser.stats['total_errors'].should == 1
   end
 
 end


### PR DESCRIPTION
At least, the parser shouldn't call on_addr when there was an address it couldn't parse. But just silently swallowing errors also isn't good, and since everything is using callbacks already, why not add an error callback? An while we're at it, we might as well count the number of errors so the node has it easier to identify misbehaving connections.

Should the events that are currently handled with #handle_stream_error be available via callbacks too?
