### PR TITLE
Correct test for S being low

### DIFF
--- a/lib/bitcoin/ffi/openssl.rb
+++ b/lib/bitcoin/ffi/openssl.rb
@@ -251,7 +251,7 @@ module OpenSSL_EC
 
     EC_GROUP_get_order(group, order, ctx)
     BN_rshift1(halforder, order)
-    if BN_cmp(order, halforder) > 0
+    if BN_cmp(s, halforder) > 0
       BN_sub(s, order, s)
     end
 


### PR DESCRIPTION
Corrects the test for whether the S value in a signature is already low, before subtracting the order of the curve from it to make it low.