### PR TITLE
Provide more visiblity into inv bundles

### DIFF
--- a/lib/bitcoin/protocol/parser.rb
+++ b/lib/bitcoin/protocol/parser.rb
@@ -23,7 +23,7 @@ module Bitcoin
       #
       def parse_inv(payload, type=:put)
         count, payload = Protocol.unpack_var_int(payload)
-        payload.each_byte.each_slice(36){|i|
+        payload.each_byte.each_slice(36).with_index{|i, idx|
           hash = i[4..-1].reverse.pack("C32")
           case i[0]
           when 1
@@ -34,7 +34,11 @@ module Bitcoin
             end
           when 2
             if type == :put
-              @h.on_inv_block(hash)
+              if @h.respond_to?(:on_inv_block_v2)
+                @h.on_inv_block_v2(hash, idx, count)
+              else
+                @h.on_inv_block(hash)
+              end
             else
               @h.on_get_block(hash)
             end


### PR DESCRIPTION
Big testnet mess from the other day triggered a bug in toshi. It was apparently missing this hack from bitcoind: https://github.com/bitcoin/bitcoin/blob/0.8/src/main.cpp#L3423-L3427. Newer bitcoind doesn't need it due to headers-first -- which we should impl at some point.

https://github.com/coinbase/toshi/pull/184 shows how the new interface is going to be used by toshi.
With the fix toshi has properly re-processed the side chain and moved on to the correct fork.