### PR TITLE
Add test for Bitcoin.verify_message with invalid input

### DIFF
--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -322,17 +322,14 @@ module Bitcoin
     end
 
     def verify_message(address, signature, message)
-      hash = bitcoin_signed_message_hash(message)
       signature = signature.unpack("m0")[0] rescue nil # decode base64
-      raise "invalid address"           unless valid_address?(address)
-      raise "malformed base64 encoding" unless signature
-      raise "malformed signature"       unless signature.bytesize == 65
+      return unless valid_address?(address)
+      return unless signature
+      return unless signature.bytesize == 65
+      hash = bitcoin_signed_message_hash(message)
       pubkey = OpenSSL_EC.recover_compact(hash, signature)
       pubkey_to_address(pubkey) == address if pubkey
-    rescue => ex
-      p [ex.message, ex.backtrace]; false
     end
-
 
     # block count when the next retarget will take place.
     def block_next_retarget(block_height)

--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -323,9 +323,9 @@ module Bitcoin
 
     def verify_message(address, signature, message)
       signature = signature.unpack("m0")[0] rescue nil # decode base64
-      return unless valid_address?(address)
-      return unless signature
-      return unless signature.bytesize == 65
+      return false unless valid_address?(address)
+      return false unless signature
+      return false unless signature.bytesize == 65
       hash = bitcoin_signed_message_hash(message)
       pubkey = OpenSSL_EC.recover_compact(hash, signature)
       pubkey_to_address(pubkey) == address if pubkey

--- a/spec/bitcoin/bitcoin_spec.rb
+++ b/spec/bitcoin/bitcoin_spec.rb
@@ -439,12 +439,13 @@ describe 'Bitcoin Address/Hash160/PubKey' do
          "030b4c866585dd868a9d62348a9cd008d6a312937048fff31670e7e920cfc7a744"]
       ].each{|address, privkey, pubkey|
         key = Bitcoin.open_key(privkey)
-        16.times.all?{|n|
+        16.times.each { |n|
         #10_000.times.all?{|n|
         #  puts 'RAM USAGE: ' + `pmap #{Process.pid} | tail -1`[10,40].strip if (n % 1_000) == 0
           s = Bitcoin.sign_message(key.private_key_hex, key.public_key_hex, "Very secret message %d: 11" % n)
-          Bitcoin.verify_message(s['address'], s['signature'], s['message'])
-        }.should == true
+          Bitcoin.verify_message(s['address'], 'invalid-signature', s['message']).should == false
+          Bitcoin.verify_message(s['address'], s['signature'], s['message']).should == true
+        }
       }
     end
   rescue LoadError


### PR DESCRIPTION
Added a test for the case when this method receives invalid input.
Removed the catch-all "rescue" which printed the error to STDOUT on failure.