### PR TITLE
Avoid polluting global scope in specs

### DIFF
--- a/spec/bitcoin/builder_spec.rb
+++ b/spec/bitcoin/builder_spec.rb
@@ -2,318 +2,318 @@
 
 require_relative 'spec_helper'
 
-include Bitcoin::Builder
+module Bitcoin::Builder
+  describe "Bitcoin::Builder" do
 
-describe "Bitcoin::Builder" do
+    before do
+      Bitcoin.network = :spec
+      @keys = 5.times.map { Bitcoin::Key.generate }
+      @target = target = "00".ljust(64, 'f')
+      @genesis = create_block("00"*32, false)
+      @block = create_block(@genesis.hash, false, [], @keys[0])
+    end
 
-  before do
-    Bitcoin.network = :spec
-    @keys = 5.times.map { Bitcoin::Key.generate }
-    @target = target = "00".ljust(64, 'f')
-    @genesis = create_block("00"*32, false)
-    @block = create_block(@genesis.hash, false, [], @keys[0])
-  end
+    it "should build blocks" do
+      block = build_block(@target) do |b|
+        b.prev_block @block.hash
 
-  it "should build blocks" do
-    block = build_block(@target) do |b|
-      b.prev_block @block.hash
+        b.tx do |t|
+          t.input {|i| i.coinbase "foobar" }
 
-      b.tx do |t|
-        t.input {|i| i.coinbase "foobar" }
+          t.output do |o|
+            o.value 5000000000
 
-        t.output do |o|
-          o.value 5000000000
-
-          o.script do |s|
-            s.type :address
-            s.recipient @keys[0].addr
+            o.script do |s|
+              s.type :address
+              s.recipient @keys[0].addr
+            end
           end
         end
       end
+
+      block.hash[0..1].should == "00"
+      block.ver.should == 1
+      block.prev_block.should == @block.binary_hash.reverse
+      block.tx.size.should == 1
+      tx = block.tx[0]
+      tx.in.size.should == 1
+      tx.out.size.should == 1
+      tx.in[0].script_sig.should == ["foobar"].pack("H*")
+
+      tx.out[0].value.should == 5000000000
     end
 
-    block.hash[0..1].should == "00"
-    block.ver.should == 1
-    block.prev_block.should == @block.binary_hash.reverse
-    block.tx.size.should == 1
-    tx = block.tx[0]
-    tx.in.size.should == 1
-    tx.out.size.should == 1
-    tx.in[0].script_sig.should == ["foobar"].pack("H*")
+    it "should build transactions with in/outputs and signatures" do
+      tx = build_tx do |t|
+        t.input do |i|
+          i.prev_out @block.tx[0]
+          i.prev_out_index 0
+          i.signature_key @keys[0]
+        end
 
-    tx.out[0].value.should == 5000000000
-  end
+        t.output do |o|
+          o.value 123
 
-  it "should build transactions with in/outputs and signatures" do
-    tx = build_tx do |t|
-      t.input do |i|
-        i.prev_out @block.tx[0]
-        i.prev_out_index 0
-        i.signature_key @keys[0]
-      end
-
-      t.output do |o|
-        o.value 123
-
-        o.script do |s|
-          s.type :address
-          s.recipient @keys[1].addr
+          o.script do |s|
+            s.type :address
+            s.recipient @keys[1].addr
+          end
         end
       end
-    end
 
-    tx.in[0].prev_out.reverse_hth.should == block.tx[0].hash
-    tx.in[0].prev_out_index.should == 0
-    Bitcoin::Script.new(tx.in[0].script_sig).chunks[1].unpack("H*")[0].should == @keys[0].pub
+      tx.in[0].prev_out.reverse_hth.should == block.tx[0].hash
+      tx.in[0].prev_out_index.should == 0
+      Bitcoin::Script.new(tx.in[0].script_sig).chunks[1].unpack("H*")[0].should == @keys[0].pub
 
-    tx.out[0].value.should == 123
-    script = Bitcoin::Script.new(tx.out[0].pk_script)
-    script.type.should == :hash160
-    script.get_address.should == @keys[1].addr
+      tx.out[0].value.should == 123
+      script = Bitcoin::Script.new(tx.out[0].pk_script)
+      script.type.should == :hash160
+      script.get_address.should == @keys[1].addr
 
-    tx.verify_input_signature(0, block.tx[0]).should == true
-
-
-    # check shortcuts also work
-    tx2 = build_tx do |t|
-      t.input {|i| i.prev_out @block.tx[0], 0; i.signature_key @keys[0] }
-      t.output {|o| o.value 123; o.script {|s| s.recipient @keys[1].addr } }
-      t.output {|o| o.to @keys[1].addr; o.value 321 }
-      t.output {|o| o.to "deadbeef", :op_return }
-    end
-    tx2.in[0].prev_out.should == tx.in[0].prev_out
-    tx2.in[0].prev_out_index.should == tx.in[0].prev_out_index
-    tx2.out[0].value.should == tx.out[0].value
-    tx2.out[0].pk_script.should == tx.out[0].pk_script
-    Bitcoin::Script.new(tx2.out[0].pk_script).to_string.should ==
-      "OP_DUP OP_HASH160 #{@keys[1].hash160} OP_EQUALVERIFY OP_CHECKSIG"
-    Bitcoin::Script.new(tx2.out[0].pk_script).to_string.should ==
-      "OP_DUP OP_HASH160 #{@keys[1].hash160} OP_EQUALVERIFY OP_CHECKSIG"
-    tx2.out[2].value.should == 0
-  end
-
-  it "should allow txin.prev_out as tx or hash" do
-    prev_tx = @block.tx[0]
-    tx1 = build_tx do |t|
-      t.input {|i| i.prev_out prev_tx, 0 }
-    end
-    tx2 = build_tx do |t|
-      t.input {|i| i.prev_out prev_tx.hash, 0, prev_tx.out[0].pk_script }
-    end
-    tx1.in[0].should == tx2.in[0]
-  end
+      tx.verify_input_signature(0, block.tx[0]).should == true
 
 
-  it "should provide txout#to shortcut" do
-    tx1 = build_tx do |t|
-      t.output {|o| o.value 123; o.to @keys[1].addr }
-    end
-    tx2 = build_tx do |t|
-      t.output {|o| o.value 123
-        o.script {|s| s.recipient @keys[1].addr } }
-    end
-    tx1.out[0].should == tx2.out[0]
-  end
-
-  it "should build unsigned transactions and add the signature hash" do
-    tx = build_tx do |t|
-      t.input do |i|
-        i.prev_out @block.tx[0]
-        i.prev_out_index 0
-        # no signature key
+      # check shortcuts also work
+      tx2 = build_tx do |t|
+        t.input {|i| i.prev_out @block.tx[0], 0; i.signature_key @keys[0] }
+        t.output {|o| o.value 123; o.script {|s| s.recipient @keys[1].addr } }
+        t.output {|o| o.to @keys[1].addr; o.value 321 }
+        t.output {|o| o.to "deadbeef", :op_return }
       end
-      t.output do |o|
-        o.value 123
-        o.script {|s| s.recipient @keys[1].addr }
+      tx2.in[0].prev_out.should == tx.in[0].prev_out
+      tx2.in[0].prev_out_index.should == tx.in[0].prev_out_index
+      tx2.out[0].value.should == tx.out[0].value
+      tx2.out[0].pk_script.should == tx.out[0].pk_script
+      Bitcoin::Script.new(tx2.out[0].pk_script).to_string.should ==
+        "OP_DUP OP_HASH160 #{@keys[1].hash160} OP_EQUALVERIFY OP_CHECKSIG"
+      Bitcoin::Script.new(tx2.out[0].pk_script).to_string.should ==
+        "OP_DUP OP_HASH160 #{@keys[1].hash160} OP_EQUALVERIFY OP_CHECKSIG"
+      tx2.out[2].value.should == 0
+    end
+
+    it "should allow txin.prev_out as tx or hash" do
+      prev_tx = @block.tx[0]
+      tx1 = build_tx do |t|
+        t.input {|i| i.prev_out prev_tx, 0 }
       end
-    end
-
-    tx.is_a?(Bitcoin::P::Tx).should == true
-    tx.in[0].sig_hash.should != nil
-  end
-
-  it "should build unsigned multisig transactions and add the signature hash" do
-    tx1 = build_tx do |t|
-      t.input {|i| i.prev_out(@block.tx[0], 0); i.signature_key(@keys[0]) }
-      t.output do |o|
-        o.value 123
-        o.to [2, *@keys[0..2].map(&:pub)], :multisig
+      tx2 = build_tx do |t|
+        t.input {|i| i.prev_out prev_tx.hash, 0, prev_tx.out[0].pk_script }
       end
+      tx1.in[0].should == tx2.in[0]
     end
 
-    tx2 = build_tx do |t|
-      t.input do |i|
-        i.prev_out tx1, 0
-        i.signature_key @keys[0]
+
+    it "should provide txout#to shortcut" do
+      tx1 = build_tx do |t|
+        t.output {|o| o.value 123; o.to @keys[1].addr }
       end
-      t.output {|o| o.value 123; o.to @keys[0].addr }
-    end
-
-    tx2.is_a?(Bitcoin::P::Tx).should == true
-    tx2.in[0].sig_hash.should != nil
-  end
-
-  it "should build unsigned p2sh multisig transactions and add the signature hash" do
-    tx1 = build_tx do |t|
-      t.input {|i| i.prev_out(@block.tx[0], 0); i.signature_key(@keys[0]) }
-      t.output do |o|
-        o.value 123
-        o.to [2, *@keys[0..2].map(&:pub)], :p2sh_multisig
+      tx2 = build_tx do |t|
+        t.output {|o| o.value 123
+          o.script {|s| s.recipient @keys[1].addr } }
       end
+      tx1.out[0].should == tx2.out[0]
     end
 
-    tx2 = build_tx do |t|
-      t.input do |i|
-        i.prev_out tx1, 0
-        i.signature_key @keys[0]
-        i.redeem_script tx1.out[0].redeem_script
-      end
-      t.output {|o| o.value 123; o.to @keys[0].addr }
-    end
-
-    tx2.is_a?(Bitcoin::P::Tx).should == true
-    tx2.in[0].sig_hash.should != nil
-  end
-
-  it "should add change output" do
-    change_address = Bitcoin::Key.generate.addr
-    tx = build_tx(input_value: @block.tx[0].out.map(&:value).inject(:+),
-                  change_address: change_address) do |t|
-      t.input {|i| i.prev_out @block.tx[0]; i.prev_out_index 0; i.signature_key @keys[0] }
-      t.output {|o| o.value 12345; o.script {|s| s.recipient @keys[1].addr } }
-    end
-    tx.out.count.should == 2
-    tx.out.last.value.should == 50e8 - 12345
-    Bitcoin::Script.new(tx.out.last.pk_script).get_address.should == change_address
-  end
-
-  it "should add change output and leave fee" do
-    change_address = Bitcoin::Key.generate.addr
-    tx = build_tx(input_value: @block.tx[0].out.map(&:value).inject(:+),
-                  change_address: change_address, leave_fee: true) do |t|
-      t.input {|i| i.prev_out @block.tx[0]; i.prev_out_index 0; i.signature_key @keys[0] }
-      t.output {|o| o.value 12345; o.script {|s| s.recipient @keys[1].addr } }
-    end
-    tx.out.count.should == 2
-    tx.out.last.value.should == 50e8 - 12345 - Bitcoin.network[:min_tx_fee]
-    Bitcoin::Script.new(tx.out.last.pk_script).get_address.should == change_address
-
-    tx = build_tx(input_value: @block.tx[0].out.map(&:value).inject(:+),
-                  change_address: change_address, leave_fee: true) do |t|
-      t.input {|i| i.prev_out @block.tx[0]; i.prev_out_index 0; i.signature_key @keys[0] }
-      49.times { t.output {|o| o.value 1e8; o.script {|s| s.recipient @keys[1].addr } } }
-      t.output {|o| o.value(1e8 - 10000); o.script {|s| s.recipient @keys[1].addr } }
-    end
-    tx.out.size.should == 50
-    tx.out.map(&:value).inject(:+).should == 50e8 - 10000
-  end
-
-  it "randomize_outputs should not modify output values or fees" do
-    change_address = Bitcoin::Key.generate.addr
-    tx = build_tx(input_value: @block.tx[0].out.map(&:value).inject(:+),
-                  change_address: change_address, leave_fee: true) do |t|
-      t.input {|i| i.prev_out @block.tx[0]; i.prev_out_index 0; i.signature_key @keys[0] }
-      t.output {|o| o.value 12345; o.script {|s| s.recipient @keys[1].addr } }
-      t.randomize_outputs
-    end
-
-    tx.out.count.should == 2
-    tx.out.last.value.should == 50e8 - 12345 - Bitcoin.network[:min_tx_fee]
-    Bitcoin::Script.new(tx.out.last.pk_script).get_address.should == change_address
-
-    tx = build_tx(input_value: @block.tx[0].out.map(&:value).inject(:+),
-                  change_address: change_address, leave_fee: true) do |t|
-      t.input {|i| i.prev_out @block.tx[0]; i.prev_out_index 0; i.signature_key @keys[0] }
-      49.times { t.output {|o| o.value 1e8; o.script {|s| s.recipient @keys[1].addr } } }
-      t.output {|o| o.value(1e8 - 10000); o.script {|s| s.recipient @keys[1].addr } }
-      t.randomize_outputs
-    end
-    tx.out.size.should == 50
-    tx.out.map(&:value).inject(:+).should == 50e8 - 10000
-  end
-
-  it "should build op_return output" do
-    builder = TxOutBuilder.new
-    builder.to "deadbeef", :op_return
-    builder.txout.parsed_script.to_string.should == "OP_RETURN deadbeef"
-  end
-
-  it "should build op_return script" do
-    s = script {|s| s.type :op_return; s.recipient "deadbeef" }
-    Bitcoin::Script.new(s).to_string.should == "OP_RETURN deadbeef"
-  end
-
-  it "should build address script" do
-    key = Bitcoin::Key.generate
-    s = script {|s| s.type :address; s.recipient key.addr }
-    Bitcoin::Script.new(s).to_string.should ==
-      "OP_DUP OP_HASH160 #{Bitcoin.hash160_from_address(key.addr)} OP_EQUALVERIFY OP_CHECKSIG"
-  end
-
-  it "should build pubkey script" do
-    key = Bitcoin::Key.generate
-    s = script {|s| s.type :pubkey; s.recipient key.pub }
-    Bitcoin::Script.new(s).to_string.should == "#{key.pub} OP_CHECKSIG"
-  end
-
-  it "should build multisig script" do
-    keys = 3.times.map { Bitcoin::Key.generate }
-    s = script {|s| s.type :multisig; s.recipient 1, keys[0].pub, keys[1].pub }
-    Bitcoin::Script.new(s).to_string.should == "1 #{keys[0].pub} #{keys[1].pub} 2 OP_CHECKMULTISIG"
-  end
-
-  it "should build and spend multisig output" do
-    tx1 = build_tx do |t|
-      t.input {|i| i.prev_out(@block.tx[0], 0); i.signature_key(@keys[0]) }
-      t.output do |o|
-        o.value 123
-        o.to [2, *@keys[0..2].map(&:pub)], :multisig
-      end
-    end
-
-    Bitcoin::Script.new(tx1.out[0].pk_script).to_string.should ==
-      "2 #{@keys[0..2].map(&:pub).join(' ')} 3 OP_CHECKMULTISIG"
-
-    tx2 = build_tx do |t|
-      t.input do |i|
-        i.prev_out tx1, 0
-        i.signature_key @keys[0..1]
-      end
-      t.output {|o| o.value 123; o.to @keys[0].addr }
-    end
-
-    tx2.verify_input_signature(0, tx1).should == true
-  end
-
-  it "should build and spend p2sh multisig output" do
-    tx1 = build_tx do |t|
-      t.input {|i| i.prev_out(@block.tx[0], 0); i.signature_key(@keys[0]) }
-      t.output do |o|
-        o.value 123
-        o.to [2, *@keys[0..2].map(&:pub)], :p2sh_multisig
-      end
-    end
-
-    Bitcoin::Script.new(tx1.out[0].pk_script).to_string.should ==
-      "OP_HASH160 #{Bitcoin.hash160(tx1.out[0].redeem_script.hth)} OP_EQUAL"
-
-    tx2 = build_tx do |t|
-      t.input do |i|
-        i.prev_out tx1, 0
-        # provide 2 required keys for signing
-        i.signature_key @keys[0..1]
-        # provide the redeem script from the previous output
-        i.redeem_script tx1.out[0].redeem_script
+    it "should build unsigned transactions and add the signature hash" do
+      tx = build_tx do |t|
+        t.input do |i|
+          i.prev_out @block.tx[0]
+          i.prev_out_index 0
+          # no signature key
+        end
+        t.output do |o|
+          o.value 123
+          o.script {|s| s.recipient @keys[1].addr }
+        end
       end
 
-      t.output {|o| o.value 123; o.to @keys[0].addr }
+      tx.is_a?(Bitcoin::P::Tx).should == true
+      tx.in[0].sig_hash.should != nil
     end
 
-    script = Bitcoin::Script.new(tx2.in[0].script_sig, tx1.out[0].pk_script)
-    # check script execution is valid
-    script.run { true }.should == true
-    # check signatures are valid
-    tx2.verify_input_signature(0, tx1).should == true
-  end
+    it "should build unsigned multisig transactions and add the signature hash" do
+      tx1 = build_tx do |t|
+        t.input {|i| i.prev_out(@block.tx[0], 0); i.signature_key(@keys[0]) }
+        t.output do |o|
+          o.value 123
+          o.to [2, *@keys[0..2].map(&:pub)], :multisig
+        end
+      end
 
+      tx2 = build_tx do |t|
+        t.input do |i|
+          i.prev_out tx1, 0
+          i.signature_key @keys[0]
+        end
+        t.output {|o| o.value 123; o.to @keys[0].addr }
+      end
+
+      tx2.is_a?(Bitcoin::P::Tx).should == true
+      tx2.in[0].sig_hash.should != nil
+    end
+
+    it "should build unsigned p2sh multisig transactions and add the signature hash" do
+      tx1 = build_tx do |t|
+        t.input {|i| i.prev_out(@block.tx[0], 0); i.signature_key(@keys[0]) }
+        t.output do |o|
+          o.value 123
+          o.to [2, *@keys[0..2].map(&:pub)], :p2sh_multisig
+        end
+      end
+
+      tx2 = build_tx do |t|
+        t.input do |i|
+          i.prev_out tx1, 0
+          i.signature_key @keys[0]
+          i.redeem_script tx1.out[0].redeem_script
+        end
+        t.output {|o| o.value 123; o.to @keys[0].addr }
+      end
+
+      tx2.is_a?(Bitcoin::P::Tx).should == true
+      tx2.in[0].sig_hash.should != nil
+    end
+
+    it "should add change output" do
+      change_address = Bitcoin::Key.generate.addr
+      tx = build_tx(input_value: @block.tx[0].out.map(&:value).inject(:+),
+                    change_address: change_address) do |t|
+        t.input {|i| i.prev_out @block.tx[0]; i.prev_out_index 0; i.signature_key @keys[0] }
+        t.output {|o| o.value 12345; o.script {|s| s.recipient @keys[1].addr } }
+      end
+      tx.out.count.should == 2
+      tx.out.last.value.should == 50e8 - 12345
+      Bitcoin::Script.new(tx.out.last.pk_script).get_address.should == change_address
+    end
+
+    it "should add change output and leave fee" do
+      change_address = Bitcoin::Key.generate.addr
+      tx = build_tx(input_value: @block.tx[0].out.map(&:value).inject(:+),
+                    change_address: change_address, leave_fee: true) do |t|
+        t.input {|i| i.prev_out @block.tx[0]; i.prev_out_index 0; i.signature_key @keys[0] }
+        t.output {|o| o.value 12345; o.script {|s| s.recipient @keys[1].addr } }
+      end
+      tx.out.count.should == 2
+      tx.out.last.value.should == 50e8 - 12345 - Bitcoin.network[:min_tx_fee]
+      Bitcoin::Script.new(tx.out.last.pk_script).get_address.should == change_address
+
+      tx = build_tx(input_value: @block.tx[0].out.map(&:value).inject(:+),
+                    change_address: change_address, leave_fee: true) do |t|
+        t.input {|i| i.prev_out @block.tx[0]; i.prev_out_index 0; i.signature_key @keys[0] }
+        49.times { t.output {|o| o.value 1e8; o.script {|s| s.recipient @keys[1].addr } } }
+        t.output {|o| o.value(1e8 - 10000); o.script {|s| s.recipient @keys[1].addr } }
+      end
+      tx.out.size.should == 50
+      tx.out.map(&:value).inject(:+).should == 50e8 - 10000
+    end
+
+    it "randomize_outputs should not modify output values or fees" do
+      change_address = Bitcoin::Key.generate.addr
+      tx = build_tx(input_value: @block.tx[0].out.map(&:value).inject(:+),
+                    change_address: change_address, leave_fee: true) do |t|
+        t.input {|i| i.prev_out @block.tx[0]; i.prev_out_index 0; i.signature_key @keys[0] }
+        t.output {|o| o.value 12345; o.script {|s| s.recipient @keys[1].addr } }
+        t.randomize_outputs
+      end
+
+      tx.out.count.should == 2
+      tx.out.last.value.should == 50e8 - 12345 - Bitcoin.network[:min_tx_fee]
+      Bitcoin::Script.new(tx.out.last.pk_script).get_address.should == change_address
+
+      tx = build_tx(input_value: @block.tx[0].out.map(&:value).inject(:+),
+                    change_address: change_address, leave_fee: true) do |t|
+        t.input {|i| i.prev_out @block.tx[0]; i.prev_out_index 0; i.signature_key @keys[0] }
+        49.times { t.output {|o| o.value 1e8; o.script {|s| s.recipient @keys[1].addr } } }
+        t.output {|o| o.value(1e8 - 10000); o.script {|s| s.recipient @keys[1].addr } }
+        t.randomize_outputs
+      end
+      tx.out.size.should == 50
+      tx.out.map(&:value).inject(:+).should == 50e8 - 10000
+    end
+
+    it "should build op_return output" do
+      builder = TxOutBuilder.new
+      builder.to "deadbeef", :op_return
+      builder.txout.parsed_script.to_string.should == "OP_RETURN deadbeef"
+    end
+
+    it "should build op_return script" do
+      s = script {|s| s.type :op_return; s.recipient "deadbeef" }
+      Bitcoin::Script.new(s).to_string.should == "OP_RETURN deadbeef"
+    end
+
+    it "should build address script" do
+      key = Bitcoin::Key.generate
+      s = script {|s| s.type :address; s.recipient key.addr }
+      Bitcoin::Script.new(s).to_string.should ==
+        "OP_DUP OP_HASH160 #{Bitcoin.hash160_from_address(key.addr)} OP_EQUALVERIFY OP_CHECKSIG"
+    end
+
+    it "should build pubkey script" do
+      key = Bitcoin::Key.generate
+      s = script {|s| s.type :pubkey; s.recipient key.pub }
+      Bitcoin::Script.new(s).to_string.should == "#{key.pub} OP_CHECKSIG"
+    end
+
+    it "should build multisig script" do
+      keys = 3.times.map { Bitcoin::Key.generate }
+      s = script {|s| s.type :multisig; s.recipient 1, keys[0].pub, keys[1].pub }
+      Bitcoin::Script.new(s).to_string.should == "1 #{keys[0].pub} #{keys[1].pub} 2 OP_CHECKMULTISIG"
+    end
+
+    it "should build and spend multisig output" do
+      tx1 = build_tx do |t|
+        t.input {|i| i.prev_out(@block.tx[0], 0); i.signature_key(@keys[0]) }
+        t.output do |o|
+          o.value 123
+          o.to [2, *@keys[0..2].map(&:pub)], :multisig
+        end
+      end
+
+      Bitcoin::Script.new(tx1.out[0].pk_script).to_string.should ==
+        "2 #{@keys[0..2].map(&:pub).join(' ')} 3 OP_CHECKMULTISIG"
+
+      tx2 = build_tx do |t|
+        t.input do |i|
+          i.prev_out tx1, 0
+          i.signature_key @keys[0..1]
+        end
+        t.output {|o| o.value 123; o.to @keys[0].addr }
+      end
+
+      tx2.verify_input_signature(0, tx1).should == true
+    end
+
+    it "should build and spend p2sh multisig output" do
+      tx1 = build_tx do |t|
+        t.input {|i| i.prev_out(@block.tx[0], 0); i.signature_key(@keys[0]) }
+        t.output do |o|
+          o.value 123
+          o.to [2, *@keys[0..2].map(&:pub)], :p2sh_multisig
+        end
+      end
+
+      Bitcoin::Script.new(tx1.out[0].pk_script).to_string.should ==
+        "OP_HASH160 #{Bitcoin.hash160(tx1.out[0].redeem_script.hth)} OP_EQUAL"
+
+      tx2 = build_tx do |t|
+        t.input do |i|
+          i.prev_out tx1, 0
+          # provide 2 required keys for signing
+          i.signature_key @keys[0..1]
+          # provide the redeem script from the previous output
+          i.redeem_script tx1.out[0].redeem_script
+        end
+
+        t.output {|o| o.value 123; o.to @keys[0].addr }
+      end
+
+      script = Bitcoin::Script.new(tx2.in[0].script_sig, tx1.out[0].pk_script)
+      # check script execution is valid
+      script.run { true }.should == true
+      # check signatures are valid
+      tx2.verify_input_signature(0, tx1).should == true
+    end
+
+  end
 end

--- a/spec/bitcoin/dogecoin_spec.rb
+++ b/spec/bitcoin/dogecoin_spec.rb
@@ -3,174 +3,175 @@
 require_relative 'spec_helper.rb'
 require 'bitcoin/script'
 
-include Bitcoin
-include Bitcoin::Builder
+module Bitcoin
+  module Builder
+    describe 'Bitcoin::Dogecoin' do
+      it 'validate dogecoin-address' do
 
-describe 'Bitcoin::Dogecoin' do
-  it 'validate dogecoin-address' do
+        Bitcoin::network = :dogecoin_testnet
 
-    Bitcoin::network = :dogecoin_testnet
+        # Testnet address
+        Bitcoin.valid_address?("nUtMFED5VRg5xuj9QCrNFt9mVPFDXo7TTE").should == true
+        # Livenet address
+        Bitcoin.valid_address?("DSpgzjPyfQB6ZzeSbMWpaZiTTxGf2oBCs4").should == false
+        # Broken address
+        Bitcoin.valid_address?("DRjyUS2uuieEPkhZNdQz8hE5YycxVEqSXA").should == false
 
-    # Testnet address
-    Bitcoin.valid_address?("nUtMFED5VRg5xuj9QCrNFt9mVPFDXo7TTE").should == true
-    # Livenet address
-    Bitcoin.valid_address?("DSpgzjPyfQB6ZzeSbMWpaZiTTxGf2oBCs4").should == false
-    # Broken address
-    Bitcoin.valid_address?("DRjyUS2uuieEPkhZNdQz8hE5YycxVEqSXA").should == false
+        Bitcoin::network = :dogecoin
 
-    Bitcoin::network = :dogecoin
+        # Testnet address
+        Bitcoin.valid_address?("nUtMFED5VRg5xuj9QCrNFt9mVPFDXo7TTE").should == false
+        # Livenet address
+        Bitcoin.valid_address?("DSpgzjPyfQB6ZzeSbMWpaZiTTxGf2oBCs4").should == true
+        # Broken address
+        Bitcoin.valid_address?("DRjyUS2uuieEPkhZNdQz8hE5YycxVEqSXA").should == false
+      end
 
-    # Testnet address
-    Bitcoin.valid_address?("nUtMFED5VRg5xuj9QCrNFt9mVPFDXo7TTE").should == false
-    # Livenet address
-    Bitcoin.valid_address?("DSpgzjPyfQB6ZzeSbMWpaZiTTxGf2oBCs4").should == true
-    # Broken address
-    Bitcoin.valid_address?("DRjyUS2uuieEPkhZNdQz8hE5YycxVEqSXA").should == false
+      it 'should calculate retarget difficulty' do
+        Bitcoin::network = :dogecoin
+
+        prev_height = 239
+        prev_block_time = 1386475638 # Block 239
+        prev_block_bits = 0x1e0ffff0
+        last_retarget_time = 1386474927 # Block 1
+        new_difficulty = Bitcoin.block_new_target(prev_height, prev_block_time, prev_block_bits, last_retarget_time)
+        new_difficulty.to_s(16).should == 0x1e00ffff.to_s(16)
+
+        prev_height = 479
+        prev_block_time = 1386475840
+        prev_block_bits = 0x1e0fffff
+        last_retarget_time = 1386475638 # Block 239
+        new_difficulty = Bitcoin.block_new_target(prev_height, prev_block_time, prev_block_bits, last_retarget_time)
+        new_difficulty.to_s(16).should == 0x1e00ffff.to_s(16)
+
+        prev_height = 9_599
+        prev_block_time = 1386954113
+        prev_block_bits = 0x1c1a1206
+        last_retarget_time = 1386942008 # Block 9359
+        new_difficulty = Bitcoin.block_new_target(prev_height, prev_block_time, prev_block_bits, last_retarget_time)
+        new_difficulty.to_s(16).should == 0x1c15ea59.to_s(16)
+
+        # First hard-fork at 145,000, which applies to block 145,001 onwards
+        prev_height = 145_000
+        prev_block_time = 1395094679
+        prev_block_bits = 0x1b499dfd
+        last_retarget_time = 1395094427
+        new_difficulty = Bitcoin.block_new_target(prev_height, prev_block_time, prev_block_bits, last_retarget_time)
+        new_difficulty.to_s(16).should == 0x1b671062.to_s(16)
+
+        # Test case for correct rounding of modulated time - by default C++ and Ruby do not
+        # necessarily round identically
+        prev_height = 145_001
+        prev_block_time = 1395094727
+        prev_block_bits = 0x1b671062
+        last_retarget_time = 1395094679
+        new_difficulty = Bitcoin.block_new_target(prev_height, prev_block_time, prev_block_bits, last_retarget_time)
+        new_difficulty.to_s(16).should == 0x1b6558a4.to_s(16)
+
+        # Test the second hard-fork at 371,337 as well
+        prev_height = 371336
+        prev_block_time = 1410464569
+        prev_block_bits = 0x1b2fdf75
+        last_retarget_time = 1410464445
+        new_difficulty = Bitcoin.block_new_target(prev_height, prev_block_time, prev_block_bits, last_retarget_time)
+        new_difficulty.to_s(16).should == 0x1b364184.to_s(16)
+
+        prev_height = 408_596
+        prev_block_time = 1412800112
+        prev_block_bits = 0x1b033d8b
+        last_retarget_time = 1412799989 # Block 408,595
+        new_difficulty = Bitcoin.block_new_target(prev_height, prev_block_time, prev_block_bits, last_retarget_time)
+        new_difficulty.to_s(16).should == 0x1b039e52.to_s(16)
+      end
+
+      it 'should calculate reward upper bounds' do
+        Bitcoin::network = :dogecoin
+
+        Bitcoin.block_creation_reward(99000).should == 1000000 * COIN # Note this is the maximum possible, not actual reward
+        Bitcoin.block_creation_reward(144999).should == 500000 * COIN
+        Bitcoin.block_creation_reward(145000).should == 250000 * COIN # Hard-forked to remove random rewards
+        Bitcoin.block_creation_reward(199999).should == 250000 * COIN
+        Bitcoin.block_creation_reward(299999).should == 125000 * COIN
+        Bitcoin.block_creation_reward(399999).should == 62500 * COIN
+        Bitcoin.block_creation_reward(499999).should == 31250 * COIN
+        Bitcoin.block_creation_reward(599999).should == 15625 * COIN
+        Bitcoin.block_creation_reward(600000).should == 10000 * COIN
+        Bitcoin.block_creation_reward(700000).should == 10000 * COIN
+      end
+
+      it 'should calculate merkle root from AuxPoW transaction branch' do
+        # Taken directly from Dogecoin block #403,931
+
+        # Branch stored as bytes to reflect how data is stored in AuxPow class
+        branch = [
+          "\xbe\x07\x90\x78\x86\x93\x99\xfa\xcc\xaa\x76\x4c\x10\xe9\xdf\x6e\x99\x81\x70\x17\x59\xad\x18\xe1\x37\x24\xd9\xca\x58\x83\x13\x48",
+          "\x5f\x5b\xfb\x2c\x79\x54\x17\x78\x49\x9c\xab\x95\x6a\x10\x38\x87\x14\x7f\x2a\xb5\xd4\xa7\x17\xf3\x2f\x9e\xee\xbd\x29\xe1\xf8\x94",
+          "\xd8\xc6\xfe\x42\xca\x25\x07\x61\x59\xcd\x12\x1a\x5e\x20\xc4\x8c\x1b\xc5\x3a\xb9\x07\x30\x08\x3e\x44\xa3\x34\x56\x6e\xa6\xbb\xcb"
+        ]
+        mrkl_index = 0
+        target = "089b911f5e471c0e1800f3384281ebec5b372fbb6f358790a92747ade271ccdf" # Coinbase TX ID
+        Bitcoin.mrkl_branch_root(branch.map(&:hth), target, mrkl_index).should == "f29cd14243ed542d9a0b495efcb9feca1b208bb5b717dc5ac04f068d2fef595a"
+      end
+
+      it 'should calculate merkle root from AuxPoW branch' do
+        # Taken directly from Dogecoin block #403,931
+
+        # Branch stored as bytes to reflect how data is stored in AuxPow class
+        aux_branch = [
+          "\x47\xa0\x22\x8b\x06\xc9\x36\x8f\x96\xc5\xf0\x4e\xb1\x09\xf8\x2c\xef\x36\xda\xe7\xc1\xbf\x25\x4c\x1a\x3f\x78\x61\x5e\xb0\xbe\x83",
+          "\xee\x67\xde\x31\x75\x76\x58\xdd\xd7\x40\x3e\x1a\x35\xd9\xc0\x6a\x5a\x13\xe6\x68\x98\x44\x3b\x45\x8c\xd6\xa7\x1b\x66\x27\x41\x6c",
+          "\xab\x9e\xf9\xbd\xa0\x2c\xad\x27\x90\xef\x9b\xb7\xc9\xa0\x7f\xe1\x79\x1a\x9d\x5a\xe0\x43\x09\xc0\xe9\x06\x48\x19\x19\x4c\x28\x31",
+          "\xff\x51\x61\x01\x80\xf6\x4d\x33\xa8\xc1\xba\x1d\xd9\xa9\xd0\x40\x48\x88\xc9\x6e\xaf\xd1\x57\x03\x64\x35\x8b\xbe\x99\x8f\x2d\xfe",
+          "\x9e\xe4\x18\x36\x7c\x3b\xce\x06\x5e\x7c\x01\x61\x29\x6e\xaa\x0d\x54\x96\xf9\x0f\x8b\x7b\x24\xeb\xf7\x2c\xc4\xba\xa5\x60\x9a\x1f",
+          "\x0b\x35\xf3\x73\x10\xe1\xde\x3f\xa4\xe1\x37\x7c\x02\x12\x62\x20\xe1\x64\xfa\x59\xec\xfe\xdc\xf4\x71\x4e\x61\xad\x74\xcc\x4b\x08"
+        ]
+        aux_mrkl_index = 56
+        target = "0c836b86991631d34a8a68054e2f62db919b39d1ee43c27ab3344d6aa82fa609" # Block hash
+        Bitcoin.mrkl_branch_root(aux_branch.map(&:hth), target, aux_mrkl_index).should == "ce3040fdb7e37484f6a1ca4f8f5da81e6b7e404ec91102315a233e03a0c39c95" # Merkle root in coinbase script
+      end
+
+      it 'parse AuxPoW' do
+        Bitcoin::network = :dogecoin
+
+        block_hash = "60323982f9c5ff1b5a954eac9dc1269352835f47c2c5222691d80f0d50dcf053"
+        data = fixtures_file("dogecoin-block-#{block_hash}.bin")
+        block = P::Block.new(data)
+        aux_pow = block.aux_pow
+        aux_pow.nil?.should == false
+        aux_pow.mrkl_index.should == 0
+
+        parent_block_merkle_root = Bitcoin.mrkl_branch_root(aux_pow.branch.map(&:reverse_hth), aux_pow.tx.hash, aux_pow.mrkl_index)
+        parent_block_merkle_root.should == aux_pow.parent_block.mrkl_root.reverse.unpack("H*")[0]
+
+        # Find the merged mining header in the coinbase input script
+        merged_mining_header = "\xfa\xbemm"
+        script = aux_pow.tx.in[0].script
+        header_idx = script.index(merged_mining_header)
+
+        header_idx.should == 4
+
+        chain_merkle_root = Bitcoin.mrkl_branch_root(aux_pow.aux_branch.map(&:reverse_hth), block_hash, aux_pow.aux_index)
+
+        # Drop everything up to the merged mining data
+        script = script.slice(header_idx + merged_mining_header.length, chain_merkle_root.length / 2 + 8)
+
+        tx_root_hash = script.slice(0, chain_merkle_root.length / 2).unpack("H*")[0]
+        chain_merkle_root.should == tx_root_hash
+
+        merkle_branch_size = script.slice(chain_merkle_root.length / 2, 4).unpack("V")[0]
+        merkle_branch_size.should == (1 << aux_pow.aux_branch.length)
+
+        # Choose a pseudo-random slot in the chain merkle tree
+        # but have it be fixed for a size/nonce/chain combination.
+        nonce = script.slice(chain_merkle_root.length / 2 + 4, 4).unpack("V")[0]
+        rand = nonce
+        rand = rand * 1103515245 + 12345
+        rand += Bitcoin.network[:auxpow_chain_id]
+        rand = rand * 1103515245 + 12345
+
+        aux_pow.aux_index.should == (rand % merkle_branch_size)
+      end
+
+    end
   end
-
-  it 'should calculate retarget difficulty' do
-    Bitcoin::network = :dogecoin
-
-    prev_height = 239
-    prev_block_time = 1386475638 # Block 239
-    prev_block_bits = 0x1e0ffff0
-    last_retarget_time = 1386474927 # Block 1
-    new_difficulty = Bitcoin.block_new_target(prev_height, prev_block_time, prev_block_bits, last_retarget_time)
-    new_difficulty.to_s(16).should == 0x1e00ffff.to_s(16)
-
-    prev_height = 479
-    prev_block_time = 1386475840
-    prev_block_bits = 0x1e0fffff
-    last_retarget_time = 1386475638 # Block 239
-    new_difficulty = Bitcoin.block_new_target(prev_height, prev_block_time, prev_block_bits, last_retarget_time)
-    new_difficulty.to_s(16).should == 0x1e00ffff.to_s(16)
-
-    prev_height = 9_599
-    prev_block_time = 1386954113
-    prev_block_bits = 0x1c1a1206
-    last_retarget_time = 1386942008 # Block 9359
-    new_difficulty = Bitcoin.block_new_target(prev_height, prev_block_time, prev_block_bits, last_retarget_time)
-    new_difficulty.to_s(16).should == 0x1c15ea59.to_s(16)
-
-    # First hard-fork at 145,000, which applies to block 145,001 onwards
-    prev_height = 145_000
-    prev_block_time = 1395094679
-    prev_block_bits = 0x1b499dfd
-    last_retarget_time = 1395094427
-    new_difficulty = Bitcoin.block_new_target(prev_height, prev_block_time, prev_block_bits, last_retarget_time)
-    new_difficulty.to_s(16).should == 0x1b671062.to_s(16)
-
-    # Test case for correct rounding of modulated time - by default C++ and Ruby do not
-    # necessarily round identically
-    prev_height = 145_001
-    prev_block_time = 1395094727
-    prev_block_bits = 0x1b671062
-    last_retarget_time = 1395094679
-    new_difficulty = Bitcoin.block_new_target(prev_height, prev_block_time, prev_block_bits, last_retarget_time)
-    new_difficulty.to_s(16).should == 0x1b6558a4.to_s(16)
-
-    # Test the second hard-fork at 371,337 as well
-    prev_height = 371336
-    prev_block_time = 1410464569
-    prev_block_bits = 0x1b2fdf75
-    last_retarget_time = 1410464445
-    new_difficulty = Bitcoin.block_new_target(prev_height, prev_block_time, prev_block_bits, last_retarget_time)
-    new_difficulty.to_s(16).should == 0x1b364184.to_s(16)
-
-    prev_height = 408_596
-    prev_block_time = 1412800112
-    prev_block_bits = 0x1b033d8b
-    last_retarget_time = 1412799989 # Block 408,595
-    new_difficulty = Bitcoin.block_new_target(prev_height, prev_block_time, prev_block_bits, last_retarget_time)
-    new_difficulty.to_s(16).should == 0x1b039e52.to_s(16)
-  end
-
-  it 'should calculate reward upper bounds' do
-    Bitcoin::network = :dogecoin
-
-    Bitcoin.block_creation_reward(99000).should == 1000000 * COIN # Note this is the maximum possible, not actual reward
-    Bitcoin.block_creation_reward(144999).should == 500000 * COIN
-    Bitcoin.block_creation_reward(145000).should == 250000 * COIN # Hard-forked to remove random rewards
-    Bitcoin.block_creation_reward(199999).should == 250000 * COIN
-    Bitcoin.block_creation_reward(299999).should == 125000 * COIN
-    Bitcoin.block_creation_reward(399999).should == 62500 * COIN
-    Bitcoin.block_creation_reward(499999).should == 31250 * COIN
-    Bitcoin.block_creation_reward(599999).should == 15625 * COIN
-    Bitcoin.block_creation_reward(600000).should == 10000 * COIN
-    Bitcoin.block_creation_reward(700000).should == 10000 * COIN
-  end
-
-  it 'should calculate merkle root from AuxPoW transaction branch' do
-    # Taken directly from Dogecoin block #403,931
-
-    # Branch stored as bytes to reflect how data is stored in AuxPow class
-    branch = [
-      "\xbe\x07\x90\x78\x86\x93\x99\xfa\xcc\xaa\x76\x4c\x10\xe9\xdf\x6e\x99\x81\x70\x17\x59\xad\x18\xe1\x37\x24\xd9\xca\x58\x83\x13\x48",
-      "\x5f\x5b\xfb\x2c\x79\x54\x17\x78\x49\x9c\xab\x95\x6a\x10\x38\x87\x14\x7f\x2a\xb5\xd4\xa7\x17\xf3\x2f\x9e\xee\xbd\x29\xe1\xf8\x94",
-      "\xd8\xc6\xfe\x42\xca\x25\x07\x61\x59\xcd\x12\x1a\x5e\x20\xc4\x8c\x1b\xc5\x3a\xb9\x07\x30\x08\x3e\x44\xa3\x34\x56\x6e\xa6\xbb\xcb"
-    ]
-    mrkl_index = 0
-    target = "089b911f5e471c0e1800f3384281ebec5b372fbb6f358790a92747ade271ccdf" # Coinbase TX ID
-    Bitcoin.mrkl_branch_root(branch.map(&:hth), target, mrkl_index).should == "f29cd14243ed542d9a0b495efcb9feca1b208bb5b717dc5ac04f068d2fef595a"
-  end
-
-  it 'should calculate merkle root from AuxPoW branch' do
-    # Taken directly from Dogecoin block #403,931
-
-    # Branch stored as bytes to reflect how data is stored in AuxPow class
-    aux_branch = [
-      "\x47\xa0\x22\x8b\x06\xc9\x36\x8f\x96\xc5\xf0\x4e\xb1\x09\xf8\x2c\xef\x36\xda\xe7\xc1\xbf\x25\x4c\x1a\x3f\x78\x61\x5e\xb0\xbe\x83",
-      "\xee\x67\xde\x31\x75\x76\x58\xdd\xd7\x40\x3e\x1a\x35\xd9\xc0\x6a\x5a\x13\xe6\x68\x98\x44\x3b\x45\x8c\xd6\xa7\x1b\x66\x27\x41\x6c",
-      "\xab\x9e\xf9\xbd\xa0\x2c\xad\x27\x90\xef\x9b\xb7\xc9\xa0\x7f\xe1\x79\x1a\x9d\x5a\xe0\x43\x09\xc0\xe9\x06\x48\x19\x19\x4c\x28\x31",
-      "\xff\x51\x61\x01\x80\xf6\x4d\x33\xa8\xc1\xba\x1d\xd9\xa9\xd0\x40\x48\x88\xc9\x6e\xaf\xd1\x57\x03\x64\x35\x8b\xbe\x99\x8f\x2d\xfe",
-      "\x9e\xe4\x18\x36\x7c\x3b\xce\x06\x5e\x7c\x01\x61\x29\x6e\xaa\x0d\x54\x96\xf9\x0f\x8b\x7b\x24\xeb\xf7\x2c\xc4\xba\xa5\x60\x9a\x1f",
-      "\x0b\x35\xf3\x73\x10\xe1\xde\x3f\xa4\xe1\x37\x7c\x02\x12\x62\x20\xe1\x64\xfa\x59\xec\xfe\xdc\xf4\x71\x4e\x61\xad\x74\xcc\x4b\x08"
-    ]
-    aux_mrkl_index = 56
-    target = "0c836b86991631d34a8a68054e2f62db919b39d1ee43c27ab3344d6aa82fa609" # Block hash
-    Bitcoin.mrkl_branch_root(aux_branch.map(&:hth), target, aux_mrkl_index).should == "ce3040fdb7e37484f6a1ca4f8f5da81e6b7e404ec91102315a233e03a0c39c95" # Merkle root in coinbase script
-  end
-
-  it 'parse AuxPoW' do
-    Bitcoin::network = :dogecoin
-
-    block_hash = "60323982f9c5ff1b5a954eac9dc1269352835f47c2c5222691d80f0d50dcf053"
-    data = fixtures_file("dogecoin-block-#{block_hash}.bin")
-    block = P::Block.new(data)
-    aux_pow = block.aux_pow
-    aux_pow.nil?.should == false
-    aux_pow.mrkl_index.should == 0
-
-    parent_block_merkle_root = Bitcoin.mrkl_branch_root(aux_pow.branch.map(&:reverse_hth), aux_pow.tx.hash, aux_pow.mrkl_index)
-    parent_block_merkle_root.should == aux_pow.parent_block.mrkl_root.reverse.unpack("H*")[0]
-
-    # Find the merged mining header in the coinbase input script
-    merged_mining_header = "\xfa\xbemm"
-    script = aux_pow.tx.in[0].script
-    header_idx = script.index(merged_mining_header)
-
-    header_idx.should == 4
-    
-    chain_merkle_root = Bitcoin.mrkl_branch_root(aux_pow.aux_branch.map(&:reverse_hth), block_hash, aux_pow.aux_index)
-    
-    # Drop everything up to the merged mining data
-    script = script.slice(header_idx + merged_mining_header.length, chain_merkle_root.length / 2 + 8)
-
-    tx_root_hash = script.slice(0, chain_merkle_root.length / 2).unpack("H*")[0]
-    chain_merkle_root.should == tx_root_hash
-
-    merkle_branch_size = script.slice(chain_merkle_root.length / 2, 4).unpack("V")[0]
-    merkle_branch_size.should == (1 << aux_pow.aux_branch.length)
-
-    # Choose a pseudo-random slot in the chain merkle tree
-    # but have it be fixed for a size/nonce/chain combination.
-    nonce = script.slice(chain_merkle_root.length / 2 + 4, 4).unpack("V")[0]
-    rand = nonce
-    rand = rand * 1103515245 + 12345
-    rand += Bitcoin.network[:auxpow_chain_id]
-    rand = rand * 1103515245 + 12345
-
-    aux_pow.aux_index.should == (rand % merkle_branch_size)
-  end
-
 end

--- a/spec/bitcoin/protocol/aux_pow_spec.rb
+++ b/spec/bitcoin/protocol/aux_pow_spec.rb
@@ -2,44 +2,44 @@
 
 require_relative '../spec_helper.rb'
 
-include Bitcoin
+module Bitcoin
+  describe Protocol::AuxPow do
 
-describe Bitcoin::Protocol::AuxPow do
+    before do
+      Bitcoin.network = :namecoin
+      @data = fixtures_file("rawblock-auxpow.bin")
+      @blk = P::Block.new(@data)
+      @aux_pow = @blk.aux_pow
+    end
 
-  before do
-    Bitcoin.network = :namecoin
-    @data = fixtures_file("rawblock-auxpow.bin")
-    @blk = P::Block.new(@data)
-    @aux_pow = @blk.aux_pow
+    it "should parse AuxPow" do
+      @aux_pow.should != nil
+      @aux_pow.block_hash.hth.should ==
+        "b42124fd99e67ddabe52ebbfcb30a82b8c74268a320b3c5e2311000000000000"
+      @aux_pow.branch.map(&:hth).should == [
+        "6d4febe909ffec61fb8e7bf24ef4444f070f74b208502285528a9686ba792fc2",
+        "d052728459450cec6ff81072c6bd3ec2fd186eaadb09429da7cab0be73646999",
+        "64c5e7e42a6cde585602fdfda6d7e5d9232db2c176a49278268cec09f3cfcb20",
+        "4e9406d6ce9ef751242bb9a63e7c2009746b3736c356ed5d738dadd6937531e4" ]
+      @aux_pow.mrkl_index.should == 0
+      @aux_pow.aux_branch.should == []
+      @aux_pow.aux_index.should == 0
+      @aux_pow.parent_block.hash.should ==
+        "00000000000011235e3c0b328a26748c2ba830cbbfeb52beda7de699fd2421b4"
+    end
+
+    it "#to_payload" do
+      @blk.to_payload.should == @data
+      P::Block.new(@blk.to_payload).to_payload.should == @data
+    end
+
+    it "#to_hash" do
+      P::Block.from_hash(@blk.to_hash).to_payload.should == @data
+    end
+
+    it "#to_json" do
+      P::Block.from_json(@blk.to_json).to_payload.should == @data
+    end
+
   end
-
-  it "should parse AuxPow" do
-    @aux_pow.should != nil
-    @aux_pow.block_hash.hth.should ==
-      "b42124fd99e67ddabe52ebbfcb30a82b8c74268a320b3c5e2311000000000000"
-    @aux_pow.branch.map(&:hth).should == [
-      "6d4febe909ffec61fb8e7bf24ef4444f070f74b208502285528a9686ba792fc2",
-      "d052728459450cec6ff81072c6bd3ec2fd186eaadb09429da7cab0be73646999",
-      "64c5e7e42a6cde585602fdfda6d7e5d9232db2c176a49278268cec09f3cfcb20",
-      "4e9406d6ce9ef751242bb9a63e7c2009746b3736c356ed5d738dadd6937531e4" ]
-    @aux_pow.mrkl_index.should == 0
-    @aux_pow.aux_branch.should == []
-    @aux_pow.aux_index.should == 0
-    @aux_pow.parent_block.hash.should ==
-      "00000000000011235e3c0b328a26748c2ba830cbbfeb52beda7de699fd2421b4"
-  end
-
-  it "#to_payload" do
-    @blk.to_payload.should == @data
-    P::Block.new(@blk.to_payload).to_payload.should == @data
-  end
-
-  it "#to_hash" do
-    P::Block.from_hash(@blk.to_hash).to_payload.should == @data
-  end
-
-  it "#to_json" do
-    P::Block.from_json(@blk.to_json).to_payload.should == @data
-  end
-
-  end
+end

--- a/spec/bitcoin/protocol/block_spec.rb
+++ b/spec/bitcoin/protocol/block_spec.rb
@@ -1,141 +1,141 @@
 # encoding: ascii-8bit
 
 require_relative '../spec_helper.rb'
-include Bitcoin::Protocol
 
-describe 'Bitcoin::Protocol::Block' do
+module Bitcoin::Protocol
+  describe 'Bitcoin::Protocol::Block' do
 
-  before do
-    @blocks = {
-      # block 0:  00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048
-      '0' => fixtures_file('rawblock-0.bin'),
-      # block 1:  000000006a625f06636b8bb6ac7b960a8d03705d1ace08b1a19da3fdcc99ddbd
-      '1' => fixtures_file('rawblock-1.bin'),
-      # block 9:  000000008d9dc510f23c2657fc4f67bea30078cc05a90eb89e84cc475c080805
-      '9' => fixtures_file('rawblock-9.bin'),
-      # block 170:  00000000d1145790a8694403d4063f323d499e655c83426834d4ce2f8dd4a2ee
-      '170' => fixtures_file('rawblock-170.bin'),
-      # block 131025:  00000000000007d938dbdd433c5ae12a782de74abf7f566518bc2b2d0a1df145
-      '131025' => fixtures_file('rawblock-131025.bin'),
-      # block 26478:  000000000214a3f06ee99a033a7f2252762d6a18d27c3cd8c8fe2278190da9f3
-      'testnet-26478' => fixtures_file('rawblock-testnet-26478.bin'),
-      'testnet-265322' => fixtures_file('rawblock-testnet-265322.bin'),
-    }
-  end
+    before do
+      @blocks = {
+        # block 0:  00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048
+        '0' => fixtures_file('rawblock-0.bin'),
+        # block 1:  000000006a625f06636b8bb6ac7b960a8d03705d1ace08b1a19da3fdcc99ddbd
+        '1' => fixtures_file('rawblock-1.bin'),
+        # block 9:  000000008d9dc510f23c2657fc4f67bea30078cc05a90eb89e84cc475c080805
+        '9' => fixtures_file('rawblock-9.bin'),
+        # block 170:  00000000d1145790a8694403d4063f323d499e655c83426834d4ce2f8dd4a2ee
+        '170' => fixtures_file('rawblock-170.bin'),
+        # block 131025:  00000000000007d938dbdd433c5ae12a782de74abf7f566518bc2b2d0a1df145
+        '131025' => fixtures_file('rawblock-131025.bin'),
+        # block 26478:  000000000214a3f06ee99a033a7f2252762d6a18d27c3cd8c8fe2278190da9f3
+        'testnet-26478' => fixtures_file('rawblock-testnet-26478.bin'),
+        'testnet-265322' => fixtures_file('rawblock-testnet-265322.bin'),
+      }
+    end
 
-  it '#new' do
-    proc{
-      Block.new( nil )
-      @block = Block.new( @blocks['0'] )
-    }.should.not.raise Exception
+    it '#new' do
+      proc{
+        Block.new( nil )
+        @block = Block.new( @blocks['0'] )
+      }.should.not.raise Exception
 
-    proc{
-      Block.new( @blocks['0'][0..20] )
-    }.should.raise Exception
+      proc{
+        Block.new( @blocks['0'][0..20] )
+      }.should.raise Exception
 
-    block = Block.new(nil)
-    block.parse_data(@blocks['0']).should == true
-    block.header_info[7].should == 215
-    block.to_payload.should == @blocks['0']
-
-    block = Block.new(nil)
-    block.parse_data(@blocks['0'] + "AAAA").should == "AAAA"
-    block.header_info[7].should == 215
-    block.to_payload.should == @blocks['0']
-  end
-
-  it '#hash' do
-    @block.hash.should == "00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"
-  end
-
-  it '#tx' do
-    @block.tx.size.should == 1
-    @block.tx[0].is_a?(Tx).should == true
-    @block.tx[0].hash.should == "0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098"
-  end
-
-  it '#to_hash' do
-    @block.to_hash.keys.should == ["hash", "ver", "prev_block", "mrkl_root", "time", "bits", "nonce", "n_tx", "size", "tx", "mrkl_tree"]
-  end
-
-  it '#to_json' do
-    @block.to_json.should == fixtures_file('rawblock-0.json')
-    Block.new( @blocks['1'] ).to_json.should == fixtures_file('rawblock-1.json')
-    Block.new( @blocks['131025'] ).to_json.should == fixtures_file('rawblock-131025.json')
-    Block.new( @blocks['testnet-26478'] ).to_json.should == fixtures_file('rawblock-testnet-26478.json')
-    Block.from_json(@block.to_json).tx[0].in[0].sequence.should == "\xff\xff\xff\xff"
-  end
-
-  it '#to_payload' do
-    @block.to_payload.should == @block.payload
-    Block.new( @block.to_payload ).to_payload.should == @block.payload
-    Block.new( @blocks['1'] ).to_payload.should == @blocks['1']
-    Block.new( @blocks['131025'] ).to_payload.should == @blocks['131025']
-    Block.new( @blocks['testnet-26478'] ).to_payload.should == @blocks['testnet-26478']
-  end
-
-  describe "Block.from_json" do
-
-    it 'should load blocks from json' do
-      block = Block.from_json(fixtures_file('rawblock-0.json'))
+      block = Block.new(nil)
+      block.parse_data(@blocks['0']).should == true
+      block.header_info[7].should == 215
       block.to_payload.should == @blocks['0']
-      block.tx[0].in[0].sequence.should == "\xff\xff\xff\xff"
-      Block.from_json(fixtures_file('rawblock-1.json')).to_payload.should == @blocks['1']
-   
-      Block.from_json(fixtures_file('rawblock-131025.json'))
-        .to_payload.should == @blocks['131025']
-   
-      Block.from_json(fixtures_file('rawblock-testnet-26478.json'))
-        .to_payload.should == @blocks['testnet-26478']
 
-      # testnet3 block 0000000000ac85bb2530a05a4214a387e6be02b22d3348abc5e7a5d9c4ce8dab
-      block_raw = fixtures_file('block-testnet-0000000000ac85bb2530a05a4214a387e6be02b22d3348abc5e7a5d9c4ce8dab.bin')
-      Block.new(block_raw).to_payload.should == block_raw
-      # Block.from_json(Block.new(block_raw).to_json).to_payload.should == block_raw # slow test
+      block = Block.new(nil)
+      block.parse_data(@blocks['0'] + "AAAA").should == "AAAA"
+      block.header_info[7].should == 215
+      block.to_payload.should == @blocks['0']
     end
 
-    it "should work with litecoin blocks" do
-      Bitcoin.network = :litecoin # change to litecoin
-      litecoin_block = "litecoin-genesis-block-12a765e31ffd4059bada1e25190f6e98c99d9714d334efa41a195a7e7e04bfe2"
-      Block.from_json(fixtures_file(litecoin_block + '.json'))
-        .to_payload.should == fixtures_file(litecoin_block + '.bin')
-
-      json = Block.new(fixtures_file(litecoin_block + '.bin')).to_json
-      Block.from_json(json)
-        .to_payload.should == fixtures_file(litecoin_block + '.bin')
-      Block.from_json(json).hash == litecoin_block.split("-").last
-
-      litecoin_block = "litecoin-block-80ca095ed10b02e53d769eb6eaf92cd04e9e0759e5be4a8477b42911ba49c78f"
-      Block.from_json(fixtures_file(litecoin_block + '.json'))
-        .to_payload.should == fixtures_file(litecoin_block + '.bin')
-
-      json = Block.new(fixtures_file(litecoin_block + '.bin')).to_json
-      Block.from_json(json)
-        .to_payload.should == fixtures_file(litecoin_block + '.bin')
-      Block.from_json(json).hash == litecoin_block.split("-").last
-      Bitcoin.network = :bitcoin
+    it '#hash' do
+      @block.hash.should == "00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"
     end
 
-    it 'should check block hash' do
-      block = Block.from_json(fixtures_file('rawblock-0.json'))
-      h = block.to_hash
-      h['hash'][0] = "1"
-      -> { Block.from_hash(h) }.should.raise(Exception)
-        .message.should == "Block hash mismatch! Claimed: 10000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048, Actual: 00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"
+    it '#tx' do
+      @block.tx.size.should == 1
+      @block.tx[0].is_a?(Tx).should == true
+      @block.tx[0].hash.should == "0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098"
     end
 
-    it "should check merkle tree" do
-      block = Block.from_json(fixtures_file('rawblock-0.json'))
-      h = block.to_hash
-      h['tx'][0]['ver'] = 2
-      -> { Block.from_hash(h) }.should.raise(Exception)
-        .message.should.include?("Block merkle root mismatch!")
+    it '#to_hash' do
+      @block.to_hash.keys.should == ["hash", "ver", "prev_block", "mrkl_root", "time", "bits", "nonce", "n_tx", "size", "tx", "mrkl_tree"]
     end
 
-  end
+    it '#to_json' do
+      @block.to_json.should == fixtures_file('rawblock-0.json')
+      Block.new( @blocks['1'] ).to_json.should == fixtures_file('rawblock-1.json')
+      Block.new( @blocks['131025'] ).to_json.should == fixtures_file('rawblock-131025.json')
+      Block.new( @blocks['testnet-26478'] ).to_json.should == fixtures_file('rawblock-testnet-26478.json')
+      Block.from_json(@block.to_json).tx[0].in[0].sequence.should == "\xff\xff\xff\xff"
+    end
 
-  it '#header_to_json' do
-    @block.header_to_json.should == (<<-JSON).chomp
+    it '#to_payload' do
+      @block.to_payload.should == @block.payload
+      Block.new( @block.to_payload ).to_payload.should == @block.payload
+      Block.new( @blocks['1'] ).to_payload.should == @blocks['1']
+      Block.new( @blocks['131025'] ).to_payload.should == @blocks['131025']
+      Block.new( @blocks['testnet-26478'] ).to_payload.should == @blocks['testnet-26478']
+    end
+
+    describe "Block.from_json" do
+
+      it 'should load blocks from json' do
+        block = Block.from_json(fixtures_file('rawblock-0.json'))
+        block.to_payload.should == @blocks['0']
+        block.tx[0].in[0].sequence.should == "\xff\xff\xff\xff"
+        Block.from_json(fixtures_file('rawblock-1.json')).to_payload.should == @blocks['1']
+
+        Block.from_json(fixtures_file('rawblock-131025.json'))
+          .to_payload.should == @blocks['131025']
+
+        Block.from_json(fixtures_file('rawblock-testnet-26478.json'))
+          .to_payload.should == @blocks['testnet-26478']
+
+        # testnet3 block 0000000000ac85bb2530a05a4214a387e6be02b22d3348abc5e7a5d9c4ce8dab
+        block_raw = fixtures_file('block-testnet-0000000000ac85bb2530a05a4214a387e6be02b22d3348abc5e7a5d9c4ce8dab.bin')
+        Block.new(block_raw).to_payload.should == block_raw
+        # Block.from_json(Block.new(block_raw).to_json).to_payload.should == block_raw # slow test
+      end
+
+      it "should work with litecoin blocks" do
+        Bitcoin.network = :litecoin # change to litecoin
+        litecoin_block = "litecoin-genesis-block-12a765e31ffd4059bada1e25190f6e98c99d9714d334efa41a195a7e7e04bfe2"
+        Block.from_json(fixtures_file(litecoin_block + '.json'))
+          .to_payload.should == fixtures_file(litecoin_block + '.bin')
+
+        json = Block.new(fixtures_file(litecoin_block + '.bin')).to_json
+        Block.from_json(json)
+          .to_payload.should == fixtures_file(litecoin_block + '.bin')
+        Block.from_json(json).hash == litecoin_block.split("-").last
+
+        litecoin_block = "litecoin-block-80ca095ed10b02e53d769eb6eaf92cd04e9e0759e5be4a8477b42911ba49c78f"
+        Block.from_json(fixtures_file(litecoin_block + '.json'))
+          .to_payload.should == fixtures_file(litecoin_block + '.bin')
+
+        json = Block.new(fixtures_file(litecoin_block + '.bin')).to_json
+        Block.from_json(json)
+          .to_payload.should == fixtures_file(litecoin_block + '.bin')
+        Block.from_json(json).hash == litecoin_block.split("-").last
+        Bitcoin.network = :bitcoin
+      end
+
+      it 'should check block hash' do
+        block = Block.from_json(fixtures_file('rawblock-0.json'))
+        h = block.to_hash
+        h['hash'][0] = "1"
+        -> { Block.from_hash(h) }.should.raise(Exception)
+          .message.should == "Block hash mismatch! Claimed: 10000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048, Actual: 00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"
+      end
+
+      it "should check merkle tree" do
+        block = Block.from_json(fixtures_file('rawblock-0.json'))
+        h = block.to_hash
+        h['tx'][0]['ver'] = 2
+        -> { Block.from_hash(h) }.should.raise(Exception)
+          .message.should.include?("Block merkle root mismatch!")
+      end
+
+    end
+
+    it '#header_to_json' do
+      @block.header_to_json.should == (<<-JSON).chomp
 {
   "hash":"00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048",
   "ver":1,
@@ -147,34 +147,35 @@ describe 'Bitcoin::Protocol::Block' do
   "n_tx":1,
   "size":215
 }
-    JSON
-  end
+      JSON
+    end
 
-  it '#verify_mrkl_root' do
-    block0 = Block.from_json(fixtures_file('rawblock-0.json'))
-    block1 = Block.from_json(fixtures_file('rawblock-1.json'))
-    block0.tx.size.should == 1
-    block0.verify_mrkl_root.should == true
-    block0.tx << block.tx.last # test against CVE-2012-2459
-    block0.verify_mrkl_root.should == false
-    block0.tx = block1.tx
-    block0.verify_mrkl_root.should == false
-  end
+    it '#verify_mrkl_root' do
+      block0 = Block.from_json(fixtures_file('rawblock-0.json'))
+      block1 = Block.from_json(fixtures_file('rawblock-1.json'))
+      block0.tx.size.should == 1
+      block0.verify_mrkl_root.should == true
+      block0.tx << block.tx.last # test against CVE-2012-2459
+      block0.verify_mrkl_root.should == false
+      block0.tx = block1.tx
+      block0.verify_mrkl_root.should == false
+    end
 
-  it '#bip34_block_height' do
-    # block version 1
-    block = Block.from_json(fixtures_file('rawblock-131025.json'))
-    block.ver.should == 1
-    block.bip34_block_height.should == nil
-    # block version 2 (introduced by BIP_0034)
-    block = Block.from_json(fixtures_file('000000000000056b1a3d84a1e2b33cde8915a4b61c0cae14fca6d3e1490b4f98.json'))
-    block.ver.should == 2
-    block.bip34_block_height.should == 197657
-  end
+    it '#bip34_block_height' do
+      # block version 1
+      block = Block.from_json(fixtures_file('rawblock-131025.json'))
+      block.ver.should == 1
+      block.bip34_block_height.should == nil
+      # block version 2 (introduced by BIP_0034)
+      block = Block.from_json(fixtures_file('000000000000056b1a3d84a1e2b33cde8915a4b61c0cae14fca6d3e1490b4f98.json'))
+      block.ver.should == 2
+      block.bip34_block_height.should == 197657
+    end
 
-  it 'should work with huge block version' do
-    Bitcoin::P::Block.new(@blocks['testnet-265322']).hash.should ==
-      "0000000000014b351588a177be099e39afd4962cd3d58e9ab5cbe45a9cf83c8a"
-  end
+    it 'should work with huge block version' do
+      Bitcoin::P::Block.new(@blocks['testnet-265322']).hash.should ==
+        "0000000000014b351588a177be099e39afd4962cd3d58e9ab5cbe45a9cf83c8a"
+    end
 
+  end
 end

--- a/spec/bitcoin/protocol/tx_spec.rb
+++ b/spec/bitcoin/protocol/tx_spec.rb
@@ -2,624 +2,624 @@
 
 require_relative '../spec_helper.rb'
 
-include Bitcoin::Protocol
-
-describe 'Tx' do
-
-  @payload = [
-    fixtures_file('rawtx-01.bin'),
-    fixtures_file('rawtx-02.bin'),
-    fixtures_file('rawtx-03.bin'),
-  ]
-
-  @json = [
-    fixtures_file('rawtx-01.json'),
-    fixtures_file('rawtx-02.json'),
-    fixtures_file('rawtx-03.json')
-  ]
-
-
-  it '#new' do
-    proc{
-      Tx.new( nil )
-      @payload.each{|payload| Tx.new( payload ) }
-    }.should.not.raise Exception
-
-    proc{
-      Tx.new( @payload[0][0..20] )
-    }.should.raise Exception
-  end
-
-  it '#parse_data' do
-    tx = Tx.new( nil )
-
-    tx.hash.should == nil
-    tx.parse_data( @payload[0] ).should == true
-    tx.hash.size.should == 64
-
-    tx = Tx.new( nil )
-    tx.parse_data( @payload[0] + "AAAA" ).should == "AAAA"
-    tx.hash.size.should == 64
-  end
-
-  it '#hash' do
-    tx = Tx.new( @payload[0] )
-    tx.hash.size.should == 64
-    tx.hash.should == "6e9dd16625b62cfcd4bf02edb89ca1f5a8c30c4b1601507090fb28e59f2d02b4"
-    tx.binary_hash.should == "\xB4\x02-\x9F\xE5(\xFB\x90pP\x01\x16K\f\xC3\xA8\xF5\xA1\x9C\xB8\xED\x02\xBF\xD4\xFC,\xB6%f\xD1\x9Dn"
-  end
-
-  it '#normalized_hash' do
-    tx = Tx.new( @payload[0] )
-    tx.normalized_hash.size.should == 64
-    tx.normalized_hash.should == "393a12b91d5b5e2449f2d27a22ffc0af937c3796a08c8213cc37690b10302e40"
-
-    new_tx = JSON.parse(tx.to_json)
-    script =  Bitcoin::Script.from_string(new_tx['in'][0]['scriptSig'])
-    script.chunks[0].bitcoin_pushdata = Bitcoin::Script::OP_PUSHDATA2
-    script.chunks[0].bitcoin_pushdata_length = script.chunks[0].bytesize
-    new_tx['in'][0]['scriptSig'] = script.to_string
-    new_tx = Bitcoin::P::Tx.from_hash(new_tx)
-
-    new_tx.hash.should != tx.hash
-    new_tx.normalized_hash.size.should == 64
-    new_tx.normalized_hash.should == "393a12b91d5b5e2449f2d27a22ffc0af937c3796a08c8213cc37690b10302e40"
-  end
-
-  it '#to_payload' do
-    tx = Tx.new( @payload[0] )
-    tx.to_payload.size.should == @payload[0].size
-    tx.to_payload.should      == @payload[0]
-  end
-
-  it '#to_hash' do
-    tx = Tx.new( @payload[0] )
-    tx.to_hash.keys.should == ["hash", "ver", "vin_sz", "vout_sz", "lock_time", "size", "in", "out"]
-  end
-
-  it 'Tx.from_hash' do
-    orig_tx = Tx.new( @payload[0] )
-    tx = Tx.from_hash( orig_tx.to_hash )
-    tx.to_payload.size.should == @payload[0].size
-    tx.to_payload.should      == @payload[0]
-    tx.to_hash.should == orig_tx.to_hash
-    Tx.binary_from_hash( orig_tx.to_hash ).should == @payload[0]
-  end
-
-  it 'Tx.binary_from_hash' do
-    orig_tx = Tx.new( @payload[0] )
-    Tx.binary_from_hash( orig_tx.to_hash ).size.should == @payload[0].size
-    Tx.binary_from_hash( orig_tx.to_hash ).should == @payload[0]
-  end
-
-  it '#to_json' do
-    tx = Tx.new( @payload[0] )
-    tx.to_json.should == @json[0]
-
-    tx = Tx.new( @payload[1] )
-    tx.to_json.should == @json[1]
-
-    tx = Tx.new( @payload[2] )
-    tx.to_json.should == @json[2]
-
-    tx = Tx.new( fixtures_file('rawtx-2f4a2717ec8c9f077a87dde6cbe0274d5238793a3f3f492b63c744837285e58a.bin') )
-    tx.to_json.should == fixtures_file('rawtx-2f4a2717ec8c9f077a87dde6cbe0274d5238793a3f3f492b63c744837285e58a.json')
-  end
-
-  it 'Tx.from_json' do
-    tx = Tx.from_json( json_string = fixtures_file('rawtx-2f4a2717ec8c9f077a87dde6cbe0274d5238793a3f3f492b63c744837285e58a.json') )
-    tx.to_json.should == json_string
-
-    tx = Tx.from_json( json_string = fixtures_file('rawtx-testnet-a220adf1902c46a39db25a24bc4178b6a88440f977a7e2cabfdd8b5c1dd35cfb.json') )
-    tx.to_json.should == json_string
-
-    tx = Tx.from_json( json_string = fixtures_file('rawtx-testnet-e232e0055dbdca88bbaa79458683195a0b7c17c5b6c524a8d146721d4d4d652f.json') )
-    tx.to_payload.should == fixtures_file('rawtx-testnet-e232e0055dbdca88bbaa79458683195a0b7c17c5b6c524a8d146721d4d4d652f.bin')
-    tx.to_json.should    == json_string
-
-    tx = Tx.from_json( fixtures_file('rawtx-ba1ff5cd66713133c062a871a8adab92416f1e38d17786b2bf56ac5f6ffdfdf5.json') )
-    Tx.new( tx.to_payload ).to_json.should == tx.to_json
-    tx.hash.should == 'ba1ff5cd66713133c062a871a8adab92416f1e38d17786b2bf56ac5f6ffdfdf5'
-
-    # coinbase tx with non-default sequence
-    tx = Tx.from_json( json=fixtures_file('0961c660358478829505e16a1f028757e54b5bbf9758341a7546573738f31429.json'))
-    Tx.new( tx.to_payload ).to_json.should == json
-
-    # toshi format
-    Tx.from_json(fixtures_file('rawtx-02-toshi.json')).to_payload.should == Tx.from_json(fixtures_file('rawtx-02.json')).to_payload
-    Tx.from_json(fixtures_file('rawtx-03-toshi.json')).to_payload.should == Tx.from_json(fixtures_file('rawtx-03.json')).to_payload
-    Tx.from_json(fixtures_file('coinbase-toshi.json')).to_payload.should == Tx.from_json(fixtures_file('coinbase.json')).to_payload
-  end
-
-  it 'Tx.binary_from_json' do
-    Tx.binary_from_json( fixtures_file('rawtx-2f4a2717ec8c9f077a87dde6cbe0274d5238793a3f3f492b63c744837285e58a.json') ).should ==
-      fixtures_file('rawtx-2f4a2717ec8c9f077a87dde6cbe0274d5238793a3f3f492b63c744837285e58a.bin')
-  end
-  
-  it 'compares arrays of bytes' do
-    # This function is used in validating an ECDSA signature's S value
-    c1 = []
-    c2 = []
-    Bitcoin::Script::compare_big_endian(c1, c2).should == 0
-    
-    c1 = [0]
-    c2 = []
-    Bitcoin::Script::compare_big_endian(c1, c2).should == 0
-    
-    c1 = []
-    c2 = [0]
-    Bitcoin::Script::compare_big_endian(c1, c2).should == 0
-    
-    c1 = [5]
-    c2 = [5]
-    Bitcoin::Script::compare_big_endian(c1, c2).should == 0
-    
-    c1 = [04]
-    c2 = [5]
-    Bitcoin::Script::compare_big_endian(c1, c2).should == -1
-    
-    c1 = [4]
-    c2 = [05]
-    Bitcoin::Script::compare_big_endian(c1, c2).should == -1
-    
-    c1 = [5]
-    c2 = [4]
-    Bitcoin::Script::compare_big_endian(c1, c2).should == 1
-    
-    c1 = [05]
-    c2 = [004]
-    Bitcoin::Script::compare_big_endian(c1, c2).should == 1
-
-  end
-
-  it 'validates ECDSA signature format' do
-    # TX 3da75972766f0ad13319b0b461fd16823a731e44f6e9de4eb3c52d6a6fb6c8ae
-    sig_orig = ["304502210088984573e3e4f33db7df6aea313f1ce67a3ef3532ea89991494c7f018258371802206ceefc9291450dbd40d834f249658e0f64662d52a41cf14e20c9781144f2fe0701"].pack("H*")
-    Bitcoin::Script::is_der_signature?(sig_orig).should == true
-    Bitcoin::Script::is_defined_hashtype_signature?(sig_orig).should == true
-
-    # Trimmed to be too short
-    sig = sig_orig.slice(0, 8)
-    Bitcoin::Script::is_der_signature?(sig).should == false
-
-    # Zero-padded to be too long
-    sig = String.new(sig_orig)
-    sig << 0x00
-    sig << 0x00
-    Bitcoin::Script::is_der_signature?(sig).should == false
-
-    # Wrong first byte
-    sig_bytes = sig_orig.unpack("C*")
-    sig_bytes[0] = 0x20
-    sig = sig_bytes.pack("C*")
-    Bitcoin::Script::is_der_signature?(sig).should == false
-
-    # Length byte broken
-    sig_bytes = sig_orig.unpack("C*")
-    sig_bytes[1] = 0x20
-    sig = sig_bytes.pack("C*")
-    Bitcoin::Script::is_der_signature?(sig).should == false
-
-    # Incorrect R value type
-    sig_bytes = sig_orig.unpack("C*")
-    sig_bytes[2] = 0x03
-    sig = sig_bytes.pack("C*")
-    Bitcoin::Script::is_der_signature?(sig).should == false
-
-    # R value length infeasibly long
-    sig_bytes = sig_orig.unpack("C*")
-    sig_bytes[3] = sig_orig.size - 4
-    sig = sig_bytes.pack("C*")
-    Bitcoin::Script::is_der_signature?(sig).should == false
-
-    # Negative R value
-    sig_bytes = sig_orig.unpack("C*")
-    sig_bytes[4] = 0x80 | sig_bytes[4]
-    sig = sig_bytes.pack("C*")
-    Bitcoin::Script::is_der_signature?(sig).should == false
-
-    # R value excessively padded
-    sig_bytes = sig_orig.unpack("C*")
-    sig_bytes[5] = 0x00
-    sig = sig_bytes.pack("C*")
-    Bitcoin::Script::is_der_signature?(sig).should == false
-
-    # Incorrect S value type
-    sig_bytes = sig_orig.unpack("C*")
-    sig_bytes[37] = 0x03
-    sig = sig_bytes.pack("C*")
-    Bitcoin::Script::is_der_signature?(sig).should == false
-
-    # Zero S length
-    sig_bytes = sig_orig.unpack("C*")
-    sig_bytes[38] = 0x00
-    sig = sig_bytes.pack("C*")
-    Bitcoin::Script::is_der_signature?(sig).should == false
-
-    # Negative S value
-    sig_bytes = sig_orig.unpack("C*")
-    sig_bytes[39] = 0x80 | sig_bytes[39]
-    sig = sig_bytes.pack("C*")
-    Bitcoin::Script::is_der_signature?(sig).should == false
-  end
-
-  it '#verify_input_signature' do
-    # transaction-2 of block-170
-    tx          = Tx.new( fixtures_file('rawtx-f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16.bin') )
-    tx.hash.should == "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16"
-
-    # transaction-1 (coinbase) of block-9
-    outpoint_tx = Tx.new( fixtures_file('rawtx-0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9.bin') )
-    outpoint_tx.hash.should == "0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9"
-
-    tx.verify_input_signature(0, outpoint_tx).should == true
-
-
-    tx = Tx.from_json( fixtures_file('rawtx-c99c49da4c38af669dea436d3e73780dfdb6c1ecf9958baa52960e8baee30e73.json') )
-    tx.hash.should == 'c99c49da4c38af669dea436d3e73780dfdb6c1ecf9958baa52960e8baee30e73'
-
-    outpoint_tx = Tx.from_json( fixtures_file('rawtx-406b2b06bcd34d3c8733e6b79f7a394c8a431fbf4ff5ac705c93f4076bb77602.json') )
-    outpoint_tx.hash.should == '406b2b06bcd34d3c8733e6b79f7a394c8a431fbf4ff5ac705c93f4076bb77602'
-
-    tx.verify_input_signature(0, outpoint_tx).should == true
-
-
-    tx = Bitcoin::Protocol::Tx.from_json(fixtures_file('0f24294a1d23efbb49c1765cf443fba7930702752aba6d765870082fe4f13cae.json'))
-    tx.hash.should == '0f24294a1d23efbb49c1765cf443fba7930702752aba6d765870082fe4f13cae'
-    outpoint_tx = Bitcoin::Protocol::Tx.from_json(fixtures_file('aea682d68a3ea5e3583e088dcbd699a5d44d4b083f02ad0aaf2598fe1fa4dfd4.json'))
-    outpoint_tx.hash.should == 'aea682d68a3ea5e3583e088dcbd699a5d44d4b083f02ad0aaf2598fe1fa4dfd4'
-    tx.verify_input_signature(0, outpoint_tx).should == true
-
-    # SIGHASH_ANYONECANPAY transaction
-    tx = Bitcoin::Protocol::Tx.from_json(fixtures_file('51bf528ecf3c161e7c021224197dbe84f9a8564212f6207baa014c01a1668e1e.json'))
-    tx.hash.should == '51bf528ecf3c161e7c021224197dbe84f9a8564212f6207baa014c01a1668e1e'
-    outpoint_tx = Bitcoin::Protocol::Tx.from_json(fixtures_file('761d8c5210fdfd505f6dff38f740ae3728eb93d7d0971fb433f685d40a4c04f6.json'))
-    outpoint_tx.hash.should == '761d8c5210fdfd505f6dff38f740ae3728eb93d7d0971fb433f685d40a4c04f6'
-    tx.verify_input_signature(0, outpoint_tx).should == true
-
-    # BIP12/OP_EVAL does't exist.
-    tx = Bitcoin::Protocol::Tx.from_json(fixtures_file('03d7e1fa4d5fefa169431f24f7798552861b255cd55d377066fedcd088fb0e99.json'))
-    tx.hash.should == '03d7e1fa4d5fefa169431f24f7798552861b255cd55d377066fedcd088fb0e99'
-    outpoint_tx = Bitcoin::Protocol::Tx.from_json(fixtures_file('f003f0c1193019db2497a675fd05d9f2edddf9b67c59e677c48d3dbd4ed5f00b.json'))
-    outpoint_tx.hash.should == 'f003f0c1193019db2497a675fd05d9f2edddf9b67c59e677c48d3dbd4ed5f00b'
-    tx.verify_input_signature(0, outpoint_tx).should == true
-
-    # (SIGHASH_ANYONECANPAY | SIGHASH_SINGLE) p2sh transaction
-    tx = Bitcoin::P::Tx.from_json(fixtures_file('7208e5edf525f04e705fb3390194e316205b8f995c8c9fcd8c6093abe04fa27d.json'))
-    tx.hash.should == "7208e5edf525f04e705fb3390194e316205b8f995c8c9fcd8c6093abe04fa27d"
-    outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('3e58b7eed0fdb599019af08578effea25c8666bbe8e200845453cacce6314477.json'))
-    outpoint_tx.hash.should == "3e58b7eed0fdb599019af08578effea25c8666bbe8e200845453cacce6314477"
-    tx.verify_input_signature(0, outpoint_tx).should == true
-
-    # SIGHHASH_SINGLE - https://bitcointalk.org/index.php?topic=260595.0
-    tx = Bitcoin::P::Tx.from_json(fixtures_file('315ac7d4c26d69668129cc352851d9389b4a6868f1509c6c8b66bead11e2619f.json'))
-    tx.hash.should == "315ac7d4c26d69668129cc352851d9389b4a6868f1509c6c8b66bead11e2619f"
-    outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('69216b8aaa35b76d6613e5f527f4858640d986e1046238583bdad79b35e938dc.json'))
-    outpoint_tx.hash.should == "69216b8aaa35b76d6613e5f527f4858640d986e1046238583bdad79b35e938dc"
-    tx.verify_input_signature(0, outpoint_tx).should == true
-    tx.verify_input_signature(1, outpoint_tx).should == true
-
-    # 0:1:01 <signature> 0:1:01 0:1:00 <pubkey> OP_SWAP OP_1ADD OP_CHECKMULTISIG
-    tx = Bitcoin::P::Tx.from_json(fixtures_file('cd874fa8cb0e2ec2d385735d5e1fd482c4fe648533efb4c50ee53bda58e15ae2.json'))
-    tx.hash.should == "cd874fa8cb0e2ec2d385735d5e1fd482c4fe648533efb4c50ee53bda58e15ae2"
-    outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('514c46f0b61714092f15c8dfcb576c9f79b3f959989b98de3944b19d98832b58.json'))
-    outpoint_tx.hash.should == "514c46f0b61714092f15c8dfcb576c9f79b3f959989b98de3944b19d98832b58"
-    tx.verify_input_signature(0, outpoint_tx).should == true
-
-    # OP_CHECKSIG with OP_0 from mainnet a6ce7081addade7676cd2af75c4129eba6bf5e179a19c40c7d4cf6a5fe595954 output 0
-    tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-9fb65b7304aaa77ac9580823c2c06b259cc42591e5cce66d76a81b6f51cc5c28.json'))
-    tx.hash.should == "9fb65b7304aaa77ac9580823c2c06b259cc42591e5cce66d76a81b6f51cc5c28"
-    outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-a6ce7081addade7676cd2af75c4129eba6bf5e179a19c40c7d4cf6a5fe595954.json'))
-    outpoint_tx.hash.should == "a6ce7081addade7676cd2af75c4129eba6bf5e179a19c40c7d4cf6a5fe595954"
-    tx.verify_input_signature(0, outpoint_tx).should == true
-
-    # drop OP_CODESEPARATOR in subscript for signature_hash_for_input
-    tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-46224764c7870f95b58f155bce1e38d4da8e99d42dbb632d0dd7c07e092ee5aa.json'))
-    tx.hash.should == "46224764c7870f95b58f155bce1e38d4da8e99d42dbb632d0dd7c07e092ee5aa"
-    outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-bc7fd132fcf817918334822ee6d9bd95c889099c96e07ca2c1eb2cc70db63224.json'))
-    outpoint_tx.hash.should == "bc7fd132fcf817918334822ee6d9bd95c889099c96e07ca2c1eb2cc70db63224"
-    tx.verify_input_signature(0, outpoint_tx).should == true
-
-    # drop OP_CODESEPARATOR in subscript for signature_hash_for_input
-    tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-aab7ef280abbb9cc6fbaf524d2645c3daf4fcca2b3f53370e618d9cedf65f1f8.json'))
-    tx.hash.should == "aab7ef280abbb9cc6fbaf524d2645c3daf4fcca2b3f53370e618d9cedf65f1f8"
-    outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-326882a7f22b5191f1a0cc9962ca4b878cd969cf3b3a70887aece4d801a0ba5e.json'))
-    outpoint_tx.hash.should == "326882a7f22b5191f1a0cc9962ca4b878cd969cf3b3a70887aece4d801a0ba5e"
-    tx.verify_input_signature(0, outpoint_tx).should == true
-
-    # drop multisig OP_CODESEPARATOR in subscript for signature_hash_for_input
-    tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-6327783a064d4e350c454ad5cd90201aedf65b1fc524e73709c52f0163739190.json'))
-    tx.hash.should == "6327783a064d4e350c454ad5cd90201aedf65b1fc524e73709c52f0163739190"
-    outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-a955032f4d6b0c9bfe8cad8f00a8933790b9c1dc28c82e0f48e75b35da0e4944.json'))
-    outpoint_tx.hash.should == "a955032f4d6b0c9bfe8cad8f00a8933790b9c1dc28c82e0f48e75b35da0e4944"
-    tx.verify_input_signature(0, outpoint_tx).should == true
-
-    # drop multisig OP_CODESEPARATOR in subscript for signature_hash_for_input when used in ScriptSig
-    tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-eb3b82c0884e3efa6d8b0be55b4915eb20be124c9766245bcc7f34fdac32bccb.json'))
-    tx.hash.should == "eb3b82c0884e3efa6d8b0be55b4915eb20be124c9766245bcc7f34fdac32bccb"
-    outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-b8fd633e7713a43d5ac87266adc78444669b987a56b3a65fb92d58c2c4b0e84d.json'))
-    outpoint_tx.hash.should == "b8fd633e7713a43d5ac87266adc78444669b987a56b3a65fb92d58c2c4b0e84d"
-    tx.verify_input_signature(1, outpoint_tx).should == true
-
-    # OP_DUP OP_HASH160
-    tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-5df1375ffe61ac35ca178ebb0cab9ea26dedbd0e96005dfcee7e379fa513232f.json'))
-    tx.hash.should == "5df1375ffe61ac35ca178ebb0cab9ea26dedbd0e96005dfcee7e379fa513232f"
-    outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-b5b598de91787439afd5938116654e0b16b7a0d0f82742ba37564219c5afcbf9.json'))
-    outpoint_tx.hash.should == "b5b598de91787439afd5938116654e0b16b7a0d0f82742ba37564219c5afcbf9"
-    tx.verify_input_signature(0, outpoint_tx).should == true
-    outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-ab9805c6d57d7070d9a42c5176e47bb705023e6b67249fb6760880548298e742.json'))
-    outpoint_tx.hash.should == "ab9805c6d57d7070d9a42c5176e47bb705023e6b67249fb6760880548298e742"
-    tx.verify_input_signature(1, outpoint_tx).should == true
-
-    # testnet3 e335562f7e297aadeed88e5954bc4eeb8dc00b31d829eedb232e39d672b0c009
-    tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-e335562f7e297aadeed88e5954bc4eeb8dc00b31d829eedb232e39d672b0c009.json'))
-    tx.hash.should == "e335562f7e297aadeed88e5954bc4eeb8dc00b31d829eedb232e39d672b0c009"
-    prev_txs = {}
-    tx.in.map{|i| i.previous_output }.uniq.each{|i| prev_txs[i] = Bitcoin::P::Tx.from_json(fixtures_file("tx-#{i}.json")) }
-    tx.in.each.with_index{|i,idx|
-      tx.verify_input_signature(idx, prev_txs[i.previous_output]).should == true
-    }
-
-    # BIP62 rule #2 - spend transaction has operations in its signature
-    tx = Tx.new( fixtures_file('rawtx-testnet-3bc52ac063291ad92d95ddda5fd776a342083b95607ad32ed8bc6f8f7d30449e.bin') )
-    tx.hash.should == "3bc52ac063291ad92d95ddda5fd776a342083b95607ad32ed8bc6f8f7d30449e"
-    outpoint_tx = Tx.new( fixtures_file('rawtx-testnet-04fdc38d6722ab4b12d79113fc4b2896bdcc5169710690ee4e78541b98e467b4.bin') )
-    outpoint_tx.hash.should == "04fdc38d6722ab4b12d79113fc4b2896bdcc5169710690ee4e78541b98e467b4"
-    tx.verify_input_signature(0, outpoint_tx, Time.now.to_i).should == true
-    tx.verify_input_signature(0, outpoint_tx, Time.now.to_i, verify_sigpushonly: true).should == false
-
-    # BIP62 rule #6 - spend transaction has an unused "0" on the signature stack
-    tx = Tx.new( fixtures_file('rawtx-testnet-0b294c7d11dd21bcccb8393e6744fed7d4d1981a08c00e3e88838cc421f33c9f.bin') )
-    tx.hash.should == "0b294c7d11dd21bcccb8393e6744fed7d4d1981a08c00e3e88838cc421f33c9f"
-    outpoint_tx = Tx.new( fixtures_file('rawtx-testnet-f80acbd2f594d04ddb0e1cacba662132104909157dff526935a3c88abe9201a5.bin') )
-    outpoint_tx.hash.should == "f80acbd2f594d04ddb0e1cacba662132104909157dff526935a3c88abe9201a5"
-    tx.verify_input_signature(0, outpoint_tx, Time.now.to_i).should == true
-    tx.verify_input_signature(0, outpoint_tx, Time.now.to_i, verify_cleanstack: true).should == false
-
-    # Ensure BIP62 is applied to P2SH scripts
-    tx = Bitcoin::P::Tx.from_json(fixtures_file('7208e5edf525f04e705fb3390194e316205b8f995c8c9fcd8c6093abe04fa27d.json'))
-    tx.hash.should == "7208e5edf525f04e705fb3390194e316205b8f995c8c9fcd8c6093abe04fa27d"
-    outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('3e58b7eed0fdb599019af08578effea25c8666bbe8e200845453cacce6314477.json'))
-    outpoint_tx.hash.should == "3e58b7eed0fdb599019af08578effea25c8666bbe8e200845453cacce6314477"
-    tx.verify_input_signature(0, outpoint_tx).should == true
-    tx.verify_input_signature(0, outpoint_tx, Time.now.to_i, verify_low_s: true).should == false
-
-    # testnet3 P2SH check
-    tx = Bitcoin::P::Tx.from_json(fixtures_file('156e6e1b84c5c3bd3a0927b25e4119fadce6e6d5186f363317511d1d680fae9a.json'))
-    tx.hash.should == "156e6e1b84c5c3bd3a0927b25e4119fadce6e6d5186f363317511d1d680fae9a"
-    outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('8d0b238a06b5a70be75d543902d02d7a514d68d3252a949a513865ac3538874c.json'))
-    outpoint_tx.hash.should == "8d0b238a06b5a70be75d543902d02d7a514d68d3252a949a513865ac3538874c"
-    tx.verify_input_signature(0, outpoint_tx).should == true
-  end
-
-  it '#sign_input_signature' do
-    prev_tx = Tx.new( fixtures_file('rawtx-2f4a2717ec8c9f077a87dde6cbe0274d5238793a3f3f492b63c744837285e58a.bin') )
-    prev_tx.hash.should == "2f4a2717ec8c9f077a87dde6cbe0274d5238793a3f3f492b63c744837285e58a"
-
-    key = Bitcoin.open_key("56e28a425a7b588973b5db962a09b1aca7bdc4a7268cdd671d03c52a997255dc",
-      pubkey="04324c6ebdcf079db6c9209a6b715b955622561262cde13a8a1df8ae0ef030eaa1552e31f8be90c385e27883a9d82780283d19507d7fa2e1e71a1d11bc3a52caf3")
-    new_tx = Tx.new(nil)
-    new_tx.add_in( TxIn.new(prev_tx.binary_hash, 0, 0) )
-    new_tx.add_out( TxOut.value_to_address(1000000, "1BVJWLTCtjA8wRivvrCiwjNdL6KjdMUCTZ") )
-    signature_hash = new_tx.signature_hash_for_input(0, prev_tx)
-    sig = Bitcoin.sign_data(key, signature_hash)
-    new_tx.in[0].script_sig = Bitcoin::Script.to_pubkey_script_sig(sig, [pubkey].pack("H*"))
-
-    new_tx = Tx.new( new_tx.to_payload )
-    new_tx.hash.should != nil
-    new_tx.verify_input_signature(0, prev_tx).should == true
-
-
-
-    prev_tx = Tx.new( fixtures_file('rawtx-14be6fff8c6014f7c9493b4a6e4a741699173f39d74431b6b844fcb41ebb9984.bin') )
-    prev_tx.hash.should == "14be6fff8c6014f7c9493b4a6e4a741699173f39d74431b6b844fcb41ebb9984"
-
-    key = Bitcoin.open_key("115ceda6c1e02d41ce65c35a30e82fb325fe3f815898a09e1a5d28bb1cc92c6e",
-            pubkey="0409d103127d26ce93ee41f1b9b1ed4c1c243acf48e31eb5c4d88ad0342ccc010a1a8d838846cf7337f2b44bc73986c0a3cb0568fa93d068b2c8296ce8d47b1545")
-    new_tx = Tx.new(nil)
-    new_tx.add_in( TxIn.new(prev_tx.binary_hash, 0, 0) )
-    pk_script = Bitcoin::Script.to_address_script("1FEYAh1x5jeKQMPPuv3bKnKvbgVAqXvqjW")
-    new_tx.add_out( TxOut.new(1000000, pk_script) )
-    signature_hash = new_tx.signature_hash_for_input(0, prev_tx)
-    sig = Bitcoin.sign_data(key, signature_hash)
-    new_tx.in[0].script_sig = Bitcoin::Script.to_pubkey_script_sig(sig, [pubkey].pack("H*"))
-
-    new_tx = Tx.new( new_tx.to_payload )
-    new_tx.hash.should != nil
-    new_tx.verify_input_signature(0, prev_tx).should == true
-
-
-
-    prev_tx = Tx.new( fixtures_file('rawtx-b5d4e8883533f99e5903ea2cf001a133a322fa6b1370b18a16c57c946a40823d.bin') )
-    prev_tx.hash.should == "b5d4e8883533f99e5903ea2cf001a133a322fa6b1370b18a16c57c946a40823d"
-
-    key = Bitcoin.open_key("56e28a425a7b588973b5db962a09b1aca7bdc4a7268cdd671d03c52a997255dc",
-      pubkey="04324c6ebdcf079db6c9209a6b715b955622561262cde13a8a1df8ae0ef030eaa1552e31f8be90c385e27883a9d82780283d19507d7fa2e1e71a1d11bc3a52caf3")
-    new_tx = Tx.new(nil)
-    new_tx.add_in( TxIn.new(prev_tx.binary_hash, 0, 0) )
-    new_tx.add_out( TxOut.value_to_address(1000000, "14yz7fob6Q16hZu4nXfmv1kRJpSYaFtet5") )
-    signature_hash = new_tx.signature_hash_for_input(0, prev_tx)
-    sig = Bitcoin.sign_data(key, signature_hash)
-    new_tx.in[0].script_sig = Bitcoin::Script.to_pubkey_script_sig(sig, [pubkey].pack("H*"))
-
-    new_tx = Tx.new( new_tx.to_payload )
-    new_tx.hash.should != nil
-    new_tx.verify_input_signature(0, prev_tx).should == true
-
-    #File.open("rawtx-#{new_tx.hash}.bin",'wb'){|f| f.print new_tx.to_payload }
-    prev_tx = Tx.new( fixtures_file('rawtx-52250a162c7d03d2e1fbc5ebd1801a88612463314b55102171c5b5d817d2d7b2.bin') )
-    prev_tx.hash.should == "52250a162c7d03d2e1fbc5ebd1801a88612463314b55102171c5b5d817d2d7b2"
-    #File.open("rawtx-#{prev_tx.hash}.json",'wb'){|f| f.print prev_tx.to_json }
-  end
-  
-  it "#legacy_sigops_count" do
-    Tx.new(@payload[0]).legacy_sigops_count.should == 2
-    Tx.new(@payload[1]).legacy_sigops_count.should == 2
-    Tx.new(@payload[2]).legacy_sigops_count.should == 2
-    
-    # Test sig ops count in inputs too.
-    tx = Tx.new
-    txin = TxIn.new
-    txin.script_sig = Bitcoin::Script.from_string("10 OP_CHECKMULTISIGVERIFY OP_CHECKSIGVERIFY").to_binary
-    tx.add_in(txin)
-    txout = TxOut.new
-    txout.pk_script = Bitcoin::Script.from_string("5 OP_CHECKMULTISIG OP_CHECKSIG").to_binary
-    tx.add_out(txout)
-    tx.legacy_sigops_count.should == (20 + 1 + 20 + 1)
-    
-  end
-  
-  describe "Tx - is_final?" do
-    it "should be final if lock_time == 0" do
-      tx = Tx.new
-      tx.lock_time = 0
-      tx.is_final?(0,0).should == true
-      
-      # even if has non-final input:
-      txin = TxIn.new
-      txin.sequence = "\x01\x00\x00\x00"
-      tx.add_in(txin)
-      tx.is_final?(0,0).should == true
+module Bitcoin::Protocol
+  describe 'Tx' do
+
+    @payload = [
+      fixtures_file('rawtx-01.bin'),
+      fixtures_file('rawtx-02.bin'),
+      fixtures_file('rawtx-03.bin'),
+    ]
+
+    @json = [
+      fixtures_file('rawtx-01.json'),
+      fixtures_file('rawtx-02.json'),
+      fixtures_file('rawtx-03.json')
+    ]
+
+
+    it '#new' do
+      proc{
+        Tx.new( nil )
+        @payload.each{|payload| Tx.new( payload ) }
+      }.should.not.raise Exception
+
+      proc{
+        Tx.new( @payload[0][0..20] )
+      }.should.raise Exception
     end
-    
-    it "should be final if lock_time is below block_height" do
+
+    it '#parse_data' do
+      tx = Tx.new( nil )
+
+      tx.hash.should == nil
+      tx.parse_data( @payload[0] ).should == true
+      tx.hash.size.should == 64
+
+      tx = Tx.new( nil )
+      tx.parse_data( @payload[0] + "AAAA" ).should == "AAAA"
+      tx.hash.size.should == 64
+    end
+
+    it '#hash' do
+      tx = Tx.new( @payload[0] )
+      tx.hash.size.should == 64
+      tx.hash.should == "6e9dd16625b62cfcd4bf02edb89ca1f5a8c30c4b1601507090fb28e59f2d02b4"
+      tx.binary_hash.should == "\xB4\x02-\x9F\xE5(\xFB\x90pP\x01\x16K\f\xC3\xA8\xF5\xA1\x9C\xB8\xED\x02\xBF\xD4\xFC,\xB6%f\xD1\x9Dn"
+    end
+
+    it '#normalized_hash' do
+      tx = Tx.new( @payload[0] )
+      tx.normalized_hash.size.should == 64
+      tx.normalized_hash.should == "393a12b91d5b5e2449f2d27a22ffc0af937c3796a08c8213cc37690b10302e40"
+
+      new_tx = JSON.parse(tx.to_json)
+      script =  Bitcoin::Script.from_string(new_tx['in'][0]['scriptSig'])
+      script.chunks[0].bitcoin_pushdata = Bitcoin::Script::OP_PUSHDATA2
+      script.chunks[0].bitcoin_pushdata_length = script.chunks[0].bytesize
+      new_tx['in'][0]['scriptSig'] = script.to_string
+      new_tx = Bitcoin::P::Tx.from_hash(new_tx)
+
+      new_tx.hash.should != tx.hash
+      new_tx.normalized_hash.size.should == 64
+      new_tx.normalized_hash.should == "393a12b91d5b5e2449f2d27a22ffc0af937c3796a08c8213cc37690b10302e40"
+    end
+
+    it '#to_payload' do
+      tx = Tx.new( @payload[0] )
+      tx.to_payload.size.should == @payload[0].size
+      tx.to_payload.should      == @payload[0]
+    end
+
+    it '#to_hash' do
+      tx = Tx.new( @payload[0] )
+      tx.to_hash.keys.should == ["hash", "ver", "vin_sz", "vout_sz", "lock_time", "size", "in", "out"]
+    end
+
+    it 'Tx.from_hash' do
+      orig_tx = Tx.new( @payload[0] )
+      tx = Tx.from_hash( orig_tx.to_hash )
+      tx.to_payload.size.should == @payload[0].size
+      tx.to_payload.should      == @payload[0]
+      tx.to_hash.should == orig_tx.to_hash
+      Tx.binary_from_hash( orig_tx.to_hash ).should == @payload[0]
+    end
+
+    it 'Tx.binary_from_hash' do
+      orig_tx = Tx.new( @payload[0] )
+      Tx.binary_from_hash( orig_tx.to_hash ).size.should == @payload[0].size
+      Tx.binary_from_hash( orig_tx.to_hash ).should == @payload[0]
+    end
+
+    it '#to_json' do
+      tx = Tx.new( @payload[0] )
+      tx.to_json.should == @json[0]
+
+      tx = Tx.new( @payload[1] )
+      tx.to_json.should == @json[1]
+
+      tx = Tx.new( @payload[2] )
+      tx.to_json.should == @json[2]
+
+      tx = Tx.new( fixtures_file('rawtx-2f4a2717ec8c9f077a87dde6cbe0274d5238793a3f3f492b63c744837285e58a.bin') )
+      tx.to_json.should == fixtures_file('rawtx-2f4a2717ec8c9f077a87dde6cbe0274d5238793a3f3f492b63c744837285e58a.json')
+    end
+
+    it 'Tx.from_json' do
+      tx = Tx.from_json( json_string = fixtures_file('rawtx-2f4a2717ec8c9f077a87dde6cbe0274d5238793a3f3f492b63c744837285e58a.json') )
+      tx.to_json.should == json_string
+
+      tx = Tx.from_json( json_string = fixtures_file('rawtx-testnet-a220adf1902c46a39db25a24bc4178b6a88440f977a7e2cabfdd8b5c1dd35cfb.json') )
+      tx.to_json.should == json_string
+
+      tx = Tx.from_json( json_string = fixtures_file('rawtx-testnet-e232e0055dbdca88bbaa79458683195a0b7c17c5b6c524a8d146721d4d4d652f.json') )
+      tx.to_payload.should == fixtures_file('rawtx-testnet-e232e0055dbdca88bbaa79458683195a0b7c17c5b6c524a8d146721d4d4d652f.bin')
+      tx.to_json.should    == json_string
+
+      tx = Tx.from_json( fixtures_file('rawtx-ba1ff5cd66713133c062a871a8adab92416f1e38d17786b2bf56ac5f6ffdfdf5.json') )
+      Tx.new( tx.to_payload ).to_json.should == tx.to_json
+      tx.hash.should == 'ba1ff5cd66713133c062a871a8adab92416f1e38d17786b2bf56ac5f6ffdfdf5'
+
+      # coinbase tx with non-default sequence
+      tx = Tx.from_json( json=fixtures_file('0961c660358478829505e16a1f028757e54b5bbf9758341a7546573738f31429.json'))
+      Tx.new( tx.to_payload ).to_json.should == json
+
+      # toshi format
+      Tx.from_json(fixtures_file('rawtx-02-toshi.json')).to_payload.should == Tx.from_json(fixtures_file('rawtx-02.json')).to_payload
+      Tx.from_json(fixtures_file('rawtx-03-toshi.json')).to_payload.should == Tx.from_json(fixtures_file('rawtx-03.json')).to_payload
+      Tx.from_json(fixtures_file('coinbase-toshi.json')).to_payload.should == Tx.from_json(fixtures_file('coinbase.json')).to_payload
+    end
+
+    it 'Tx.binary_from_json' do
+      Tx.binary_from_json( fixtures_file('rawtx-2f4a2717ec8c9f077a87dde6cbe0274d5238793a3f3f492b63c744837285e58a.json') ).should ==
+        fixtures_file('rawtx-2f4a2717ec8c9f077a87dde6cbe0274d5238793a3f3f492b63c744837285e58a.bin')
+    end
+
+    it 'compares arrays of bytes' do
+      # This function is used in validating an ECDSA signature's S value
+      c1 = []
+      c2 = []
+      Bitcoin::Script::compare_big_endian(c1, c2).should == 0
+
+      c1 = [0]
+      c2 = []
+      Bitcoin::Script::compare_big_endian(c1, c2).should == 0
+
+      c1 = []
+      c2 = [0]
+      Bitcoin::Script::compare_big_endian(c1, c2).should == 0
+
+      c1 = [5]
+      c2 = [5]
+      Bitcoin::Script::compare_big_endian(c1, c2).should == 0
+
+      c1 = [04]
+      c2 = [5]
+      Bitcoin::Script::compare_big_endian(c1, c2).should == -1
+
+      c1 = [4]
+      c2 = [05]
+      Bitcoin::Script::compare_big_endian(c1, c2).should == -1
+
+      c1 = [5]
+      c2 = [4]
+      Bitcoin::Script::compare_big_endian(c1, c2).should == 1
+
+      c1 = [05]
+      c2 = [004]
+      Bitcoin::Script::compare_big_endian(c1, c2).should == 1
+
+    end
+
+    it 'validates ECDSA signature format' do
+      # TX 3da75972766f0ad13319b0b461fd16823a731e44f6e9de4eb3c52d6a6fb6c8ae
+      sig_orig = ["304502210088984573e3e4f33db7df6aea313f1ce67a3ef3532ea89991494c7f018258371802206ceefc9291450dbd40d834f249658e0f64662d52a41cf14e20c9781144f2fe0701"].pack("H*")
+      Bitcoin::Script::is_der_signature?(sig_orig).should == true
+      Bitcoin::Script::is_defined_hashtype_signature?(sig_orig).should == true
+
+      # Trimmed to be too short
+      sig = sig_orig.slice(0, 8)
+      Bitcoin::Script::is_der_signature?(sig).should == false
+
+      # Zero-padded to be too long
+      sig = String.new(sig_orig)
+      sig << 0x00
+      sig << 0x00
+      Bitcoin::Script::is_der_signature?(sig).should == false
+
+      # Wrong first byte
+      sig_bytes = sig_orig.unpack("C*")
+      sig_bytes[0] = 0x20
+      sig = sig_bytes.pack("C*")
+      Bitcoin::Script::is_der_signature?(sig).should == false
+
+      # Length byte broken
+      sig_bytes = sig_orig.unpack("C*")
+      sig_bytes[1] = 0x20
+      sig = sig_bytes.pack("C*")
+      Bitcoin::Script::is_der_signature?(sig).should == false
+
+      # Incorrect R value type
+      sig_bytes = sig_orig.unpack("C*")
+      sig_bytes[2] = 0x03
+      sig = sig_bytes.pack("C*")
+      Bitcoin::Script::is_der_signature?(sig).should == false
+
+      # R value length infeasibly long
+      sig_bytes = sig_orig.unpack("C*")
+      sig_bytes[3] = sig_orig.size - 4
+      sig = sig_bytes.pack("C*")
+      Bitcoin::Script::is_der_signature?(sig).should == false
+
+      # Negative R value
+      sig_bytes = sig_orig.unpack("C*")
+      sig_bytes[4] = 0x80 | sig_bytes[4]
+      sig = sig_bytes.pack("C*")
+      Bitcoin::Script::is_der_signature?(sig).should == false
+
+      # R value excessively padded
+      sig_bytes = sig_orig.unpack("C*")
+      sig_bytes[5] = 0x00
+      sig = sig_bytes.pack("C*")
+      Bitcoin::Script::is_der_signature?(sig).should == false
+
+      # Incorrect S value type
+      sig_bytes = sig_orig.unpack("C*")
+      sig_bytes[37] = 0x03
+      sig = sig_bytes.pack("C*")
+      Bitcoin::Script::is_der_signature?(sig).should == false
+
+      # Zero S length
+      sig_bytes = sig_orig.unpack("C*")
+      sig_bytes[38] = 0x00
+      sig = sig_bytes.pack("C*")
+      Bitcoin::Script::is_der_signature?(sig).should == false
+
+      # Negative S value
+      sig_bytes = sig_orig.unpack("C*")
+      sig_bytes[39] = 0x80 | sig_bytes[39]
+      sig = sig_bytes.pack("C*")
+      Bitcoin::Script::is_der_signature?(sig).should == false
+    end
+
+    it '#verify_input_signature' do
+      # transaction-2 of block-170
+      tx          = Tx.new( fixtures_file('rawtx-f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16.bin') )
+      tx.hash.should == "f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16"
+
+      # transaction-1 (coinbase) of block-9
+      outpoint_tx = Tx.new( fixtures_file('rawtx-0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9.bin') )
+      outpoint_tx.hash.should == "0437cd7f8525ceed2324359c2d0ba26006d92d856a9c20fa0241106ee5a597c9"
+
+      tx.verify_input_signature(0, outpoint_tx).should == true
+
+
+      tx = Tx.from_json( fixtures_file('rawtx-c99c49da4c38af669dea436d3e73780dfdb6c1ecf9958baa52960e8baee30e73.json') )
+      tx.hash.should == 'c99c49da4c38af669dea436d3e73780dfdb6c1ecf9958baa52960e8baee30e73'
+
+      outpoint_tx = Tx.from_json( fixtures_file('rawtx-406b2b06bcd34d3c8733e6b79f7a394c8a431fbf4ff5ac705c93f4076bb77602.json') )
+      outpoint_tx.hash.should == '406b2b06bcd34d3c8733e6b79f7a394c8a431fbf4ff5ac705c93f4076bb77602'
+
+      tx.verify_input_signature(0, outpoint_tx).should == true
+
+
+      tx = Bitcoin::Protocol::Tx.from_json(fixtures_file('0f24294a1d23efbb49c1765cf443fba7930702752aba6d765870082fe4f13cae.json'))
+      tx.hash.should == '0f24294a1d23efbb49c1765cf443fba7930702752aba6d765870082fe4f13cae'
+      outpoint_tx = Bitcoin::Protocol::Tx.from_json(fixtures_file('aea682d68a3ea5e3583e088dcbd699a5d44d4b083f02ad0aaf2598fe1fa4dfd4.json'))
+      outpoint_tx.hash.should == 'aea682d68a3ea5e3583e088dcbd699a5d44d4b083f02ad0aaf2598fe1fa4dfd4'
+      tx.verify_input_signature(0, outpoint_tx).should == true
+
+      # SIGHASH_ANYONECANPAY transaction
+      tx = Bitcoin::Protocol::Tx.from_json(fixtures_file('51bf528ecf3c161e7c021224197dbe84f9a8564212f6207baa014c01a1668e1e.json'))
+      tx.hash.should == '51bf528ecf3c161e7c021224197dbe84f9a8564212f6207baa014c01a1668e1e'
+      outpoint_tx = Bitcoin::Protocol::Tx.from_json(fixtures_file('761d8c5210fdfd505f6dff38f740ae3728eb93d7d0971fb433f685d40a4c04f6.json'))
+      outpoint_tx.hash.should == '761d8c5210fdfd505f6dff38f740ae3728eb93d7d0971fb433f685d40a4c04f6'
+      tx.verify_input_signature(0, outpoint_tx).should == true
+
+      # BIP12/OP_EVAL does't exist.
+      tx = Bitcoin::Protocol::Tx.from_json(fixtures_file('03d7e1fa4d5fefa169431f24f7798552861b255cd55d377066fedcd088fb0e99.json'))
+      tx.hash.should == '03d7e1fa4d5fefa169431f24f7798552861b255cd55d377066fedcd088fb0e99'
+      outpoint_tx = Bitcoin::Protocol::Tx.from_json(fixtures_file('f003f0c1193019db2497a675fd05d9f2edddf9b67c59e677c48d3dbd4ed5f00b.json'))
+      outpoint_tx.hash.should == 'f003f0c1193019db2497a675fd05d9f2edddf9b67c59e677c48d3dbd4ed5f00b'
+      tx.verify_input_signature(0, outpoint_tx).should == true
+
+      # (SIGHASH_ANYONECANPAY | SIGHASH_SINGLE) p2sh transaction
+      tx = Bitcoin::P::Tx.from_json(fixtures_file('7208e5edf525f04e705fb3390194e316205b8f995c8c9fcd8c6093abe04fa27d.json'))
+      tx.hash.should == "7208e5edf525f04e705fb3390194e316205b8f995c8c9fcd8c6093abe04fa27d"
+      outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('3e58b7eed0fdb599019af08578effea25c8666bbe8e200845453cacce6314477.json'))
+      outpoint_tx.hash.should == "3e58b7eed0fdb599019af08578effea25c8666bbe8e200845453cacce6314477"
+      tx.verify_input_signature(0, outpoint_tx).should == true
+
+      # SIGHHASH_SINGLE - https://bitcointalk.org/index.php?topic=260595.0
+      tx = Bitcoin::P::Tx.from_json(fixtures_file('315ac7d4c26d69668129cc352851d9389b4a6868f1509c6c8b66bead11e2619f.json'))
+      tx.hash.should == "315ac7d4c26d69668129cc352851d9389b4a6868f1509c6c8b66bead11e2619f"
+      outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('69216b8aaa35b76d6613e5f527f4858640d986e1046238583bdad79b35e938dc.json'))
+      outpoint_tx.hash.should == "69216b8aaa35b76d6613e5f527f4858640d986e1046238583bdad79b35e938dc"
+      tx.verify_input_signature(0, outpoint_tx).should == true
+      tx.verify_input_signature(1, outpoint_tx).should == true
+
+      # 0:1:01 <signature> 0:1:01 0:1:00 <pubkey> OP_SWAP OP_1ADD OP_CHECKMULTISIG
+      tx = Bitcoin::P::Tx.from_json(fixtures_file('cd874fa8cb0e2ec2d385735d5e1fd482c4fe648533efb4c50ee53bda58e15ae2.json'))
+      tx.hash.should == "cd874fa8cb0e2ec2d385735d5e1fd482c4fe648533efb4c50ee53bda58e15ae2"
+      outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('514c46f0b61714092f15c8dfcb576c9f79b3f959989b98de3944b19d98832b58.json'))
+      outpoint_tx.hash.should == "514c46f0b61714092f15c8dfcb576c9f79b3f959989b98de3944b19d98832b58"
+      tx.verify_input_signature(0, outpoint_tx).should == true
+
+      # OP_CHECKSIG with OP_0 from mainnet a6ce7081addade7676cd2af75c4129eba6bf5e179a19c40c7d4cf6a5fe595954 output 0
+      tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-9fb65b7304aaa77ac9580823c2c06b259cc42591e5cce66d76a81b6f51cc5c28.json'))
+      tx.hash.should == "9fb65b7304aaa77ac9580823c2c06b259cc42591e5cce66d76a81b6f51cc5c28"
+      outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-a6ce7081addade7676cd2af75c4129eba6bf5e179a19c40c7d4cf6a5fe595954.json'))
+      outpoint_tx.hash.should == "a6ce7081addade7676cd2af75c4129eba6bf5e179a19c40c7d4cf6a5fe595954"
+      tx.verify_input_signature(0, outpoint_tx).should == true
+
+      # drop OP_CODESEPARATOR in subscript for signature_hash_for_input
+      tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-46224764c7870f95b58f155bce1e38d4da8e99d42dbb632d0dd7c07e092ee5aa.json'))
+      tx.hash.should == "46224764c7870f95b58f155bce1e38d4da8e99d42dbb632d0dd7c07e092ee5aa"
+      outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-bc7fd132fcf817918334822ee6d9bd95c889099c96e07ca2c1eb2cc70db63224.json'))
+      outpoint_tx.hash.should == "bc7fd132fcf817918334822ee6d9bd95c889099c96e07ca2c1eb2cc70db63224"
+      tx.verify_input_signature(0, outpoint_tx).should == true
+
+      # drop OP_CODESEPARATOR in subscript for signature_hash_for_input
+      tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-aab7ef280abbb9cc6fbaf524d2645c3daf4fcca2b3f53370e618d9cedf65f1f8.json'))
+      tx.hash.should == "aab7ef280abbb9cc6fbaf524d2645c3daf4fcca2b3f53370e618d9cedf65f1f8"
+      outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-326882a7f22b5191f1a0cc9962ca4b878cd969cf3b3a70887aece4d801a0ba5e.json'))
+      outpoint_tx.hash.should == "326882a7f22b5191f1a0cc9962ca4b878cd969cf3b3a70887aece4d801a0ba5e"
+      tx.verify_input_signature(0, outpoint_tx).should == true
+
+      # drop multisig OP_CODESEPARATOR in subscript for signature_hash_for_input
+      tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-6327783a064d4e350c454ad5cd90201aedf65b1fc524e73709c52f0163739190.json'))
+      tx.hash.should == "6327783a064d4e350c454ad5cd90201aedf65b1fc524e73709c52f0163739190"
+      outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-a955032f4d6b0c9bfe8cad8f00a8933790b9c1dc28c82e0f48e75b35da0e4944.json'))
+      outpoint_tx.hash.should == "a955032f4d6b0c9bfe8cad8f00a8933790b9c1dc28c82e0f48e75b35da0e4944"
+      tx.verify_input_signature(0, outpoint_tx).should == true
+
+      # drop multisig OP_CODESEPARATOR in subscript for signature_hash_for_input when used in ScriptSig
+      tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-eb3b82c0884e3efa6d8b0be55b4915eb20be124c9766245bcc7f34fdac32bccb.json'))
+      tx.hash.should == "eb3b82c0884e3efa6d8b0be55b4915eb20be124c9766245bcc7f34fdac32bccb"
+      outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-b8fd633e7713a43d5ac87266adc78444669b987a56b3a65fb92d58c2c4b0e84d.json'))
+      outpoint_tx.hash.should == "b8fd633e7713a43d5ac87266adc78444669b987a56b3a65fb92d58c2c4b0e84d"
+      tx.verify_input_signature(1, outpoint_tx).should == true
+
+      # OP_DUP OP_HASH160
+      tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-5df1375ffe61ac35ca178ebb0cab9ea26dedbd0e96005dfcee7e379fa513232f.json'))
+      tx.hash.should == "5df1375ffe61ac35ca178ebb0cab9ea26dedbd0e96005dfcee7e379fa513232f"
+      outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-b5b598de91787439afd5938116654e0b16b7a0d0f82742ba37564219c5afcbf9.json'))
+      outpoint_tx.hash.should == "b5b598de91787439afd5938116654e0b16b7a0d0f82742ba37564219c5afcbf9"
+      tx.verify_input_signature(0, outpoint_tx).should == true
+      outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-ab9805c6d57d7070d9a42c5176e47bb705023e6b67249fb6760880548298e742.json'))
+      outpoint_tx.hash.should == "ab9805c6d57d7070d9a42c5176e47bb705023e6b67249fb6760880548298e742"
+      tx.verify_input_signature(1, outpoint_tx).should == true
+
+      # testnet3 e335562f7e297aadeed88e5954bc4eeb8dc00b31d829eedb232e39d672b0c009
+      tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-e335562f7e297aadeed88e5954bc4eeb8dc00b31d829eedb232e39d672b0c009.json'))
+      tx.hash.should == "e335562f7e297aadeed88e5954bc4eeb8dc00b31d829eedb232e39d672b0c009"
+      prev_txs = {}
+      tx.in.map{|i| i.previous_output }.uniq.each{|i| prev_txs[i] = Bitcoin::P::Tx.from_json(fixtures_file("tx-#{i}.json")) }
+      tx.in.each.with_index{|i,idx|
+        tx.verify_input_signature(idx, prev_txs[i.previous_output]).should == true
+      }
+
+      # BIP62 rule #2 - spend transaction has operations in its signature
+      tx = Tx.new( fixtures_file('rawtx-testnet-3bc52ac063291ad92d95ddda5fd776a342083b95607ad32ed8bc6f8f7d30449e.bin') )
+      tx.hash.should == "3bc52ac063291ad92d95ddda5fd776a342083b95607ad32ed8bc6f8f7d30449e"
+      outpoint_tx = Tx.new( fixtures_file('rawtx-testnet-04fdc38d6722ab4b12d79113fc4b2896bdcc5169710690ee4e78541b98e467b4.bin') )
+      outpoint_tx.hash.should == "04fdc38d6722ab4b12d79113fc4b2896bdcc5169710690ee4e78541b98e467b4"
+      tx.verify_input_signature(0, outpoint_tx, Time.now.to_i).should == true
+      tx.verify_input_signature(0, outpoint_tx, Time.now.to_i, verify_sigpushonly: true).should == false
+
+      # BIP62 rule #6 - spend transaction has an unused "0" on the signature stack
+      tx = Tx.new( fixtures_file('rawtx-testnet-0b294c7d11dd21bcccb8393e6744fed7d4d1981a08c00e3e88838cc421f33c9f.bin') )
+      tx.hash.should == "0b294c7d11dd21bcccb8393e6744fed7d4d1981a08c00e3e88838cc421f33c9f"
+      outpoint_tx = Tx.new( fixtures_file('rawtx-testnet-f80acbd2f594d04ddb0e1cacba662132104909157dff526935a3c88abe9201a5.bin') )
+      outpoint_tx.hash.should == "f80acbd2f594d04ddb0e1cacba662132104909157dff526935a3c88abe9201a5"
+      tx.verify_input_signature(0, outpoint_tx, Time.now.to_i).should == true
+      tx.verify_input_signature(0, outpoint_tx, Time.now.to_i, verify_cleanstack: true).should == false
+
+      # Ensure BIP62 is applied to P2SH scripts
+      tx = Bitcoin::P::Tx.from_json(fixtures_file('7208e5edf525f04e705fb3390194e316205b8f995c8c9fcd8c6093abe04fa27d.json'))
+      tx.hash.should == "7208e5edf525f04e705fb3390194e316205b8f995c8c9fcd8c6093abe04fa27d"
+      outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('3e58b7eed0fdb599019af08578effea25c8666bbe8e200845453cacce6314477.json'))
+      outpoint_tx.hash.should == "3e58b7eed0fdb599019af08578effea25c8666bbe8e200845453cacce6314477"
+      tx.verify_input_signature(0, outpoint_tx).should == true
+      tx.verify_input_signature(0, outpoint_tx, Time.now.to_i, verify_low_s: true).should == false
+
+      # testnet3 P2SH check
+      tx = Bitcoin::P::Tx.from_json(fixtures_file('156e6e1b84c5c3bd3a0927b25e4119fadce6e6d5186f363317511d1d680fae9a.json'))
+      tx.hash.should == "156e6e1b84c5c3bd3a0927b25e4119fadce6e6d5186f363317511d1d680fae9a"
+      outpoint_tx = Bitcoin::P::Tx.from_json(fixtures_file('8d0b238a06b5a70be75d543902d02d7a514d68d3252a949a513865ac3538874c.json'))
+      outpoint_tx.hash.should == "8d0b238a06b5a70be75d543902d02d7a514d68d3252a949a513865ac3538874c"
+      tx.verify_input_signature(0, outpoint_tx).should == true
+    end
+
+    it '#sign_input_signature' do
+      prev_tx = Tx.new( fixtures_file('rawtx-2f4a2717ec8c9f077a87dde6cbe0274d5238793a3f3f492b63c744837285e58a.bin') )
+      prev_tx.hash.should == "2f4a2717ec8c9f077a87dde6cbe0274d5238793a3f3f492b63c744837285e58a"
+
+      key = Bitcoin.open_key("56e28a425a7b588973b5db962a09b1aca7bdc4a7268cdd671d03c52a997255dc",
+        pubkey="04324c6ebdcf079db6c9209a6b715b955622561262cde13a8a1df8ae0ef030eaa1552e31f8be90c385e27883a9d82780283d19507d7fa2e1e71a1d11bc3a52caf3")
+      new_tx = Tx.new(nil)
+      new_tx.add_in( TxIn.new(prev_tx.binary_hash, 0, 0) )
+      new_tx.add_out( TxOut.value_to_address(1000000, "1BVJWLTCtjA8wRivvrCiwjNdL6KjdMUCTZ") )
+      signature_hash = new_tx.signature_hash_for_input(0, prev_tx)
+      sig = Bitcoin.sign_data(key, signature_hash)
+      new_tx.in[0].script_sig = Bitcoin::Script.to_pubkey_script_sig(sig, [pubkey].pack("H*"))
+
+      new_tx = Tx.new( new_tx.to_payload )
+      new_tx.hash.should != nil
+      new_tx.verify_input_signature(0, prev_tx).should == true
+
+
+
+      prev_tx = Tx.new( fixtures_file('rawtx-14be6fff8c6014f7c9493b4a6e4a741699173f39d74431b6b844fcb41ebb9984.bin') )
+      prev_tx.hash.should == "14be6fff8c6014f7c9493b4a6e4a741699173f39d74431b6b844fcb41ebb9984"
+
+      key = Bitcoin.open_key("115ceda6c1e02d41ce65c35a30e82fb325fe3f815898a09e1a5d28bb1cc92c6e",
+              pubkey="0409d103127d26ce93ee41f1b9b1ed4c1c243acf48e31eb5c4d88ad0342ccc010a1a8d838846cf7337f2b44bc73986c0a3cb0568fa93d068b2c8296ce8d47b1545")
+      new_tx = Tx.new(nil)
+      new_tx.add_in( TxIn.new(prev_tx.binary_hash, 0, 0) )
+      pk_script = Bitcoin::Script.to_address_script("1FEYAh1x5jeKQMPPuv3bKnKvbgVAqXvqjW")
+      new_tx.add_out( TxOut.new(1000000, pk_script) )
+      signature_hash = new_tx.signature_hash_for_input(0, prev_tx)
+      sig = Bitcoin.sign_data(key, signature_hash)
+      new_tx.in[0].script_sig = Bitcoin::Script.to_pubkey_script_sig(sig, [pubkey].pack("H*"))
+
+      new_tx = Tx.new( new_tx.to_payload )
+      new_tx.hash.should != nil
+      new_tx.verify_input_signature(0, prev_tx).should == true
+
+
+
+      prev_tx = Tx.new( fixtures_file('rawtx-b5d4e8883533f99e5903ea2cf001a133a322fa6b1370b18a16c57c946a40823d.bin') )
+      prev_tx.hash.should == "b5d4e8883533f99e5903ea2cf001a133a322fa6b1370b18a16c57c946a40823d"
+
+      key = Bitcoin.open_key("56e28a425a7b588973b5db962a09b1aca7bdc4a7268cdd671d03c52a997255dc",
+        pubkey="04324c6ebdcf079db6c9209a6b715b955622561262cde13a8a1df8ae0ef030eaa1552e31f8be90c385e27883a9d82780283d19507d7fa2e1e71a1d11bc3a52caf3")
+      new_tx = Tx.new(nil)
+      new_tx.add_in( TxIn.new(prev_tx.binary_hash, 0, 0) )
+      new_tx.add_out( TxOut.value_to_address(1000000, "14yz7fob6Q16hZu4nXfmv1kRJpSYaFtet5") )
+      signature_hash = new_tx.signature_hash_for_input(0, prev_tx)
+      sig = Bitcoin.sign_data(key, signature_hash)
+      new_tx.in[0].script_sig = Bitcoin::Script.to_pubkey_script_sig(sig, [pubkey].pack("H*"))
+
+      new_tx = Tx.new( new_tx.to_payload )
+      new_tx.hash.should != nil
+      new_tx.verify_input_signature(0, prev_tx).should == true
+
+      #File.open("rawtx-#{new_tx.hash}.bin",'wb'){|f| f.print new_tx.to_payload }
+      prev_tx = Tx.new( fixtures_file('rawtx-52250a162c7d03d2e1fbc5ebd1801a88612463314b55102171c5b5d817d2d7b2.bin') )
+      prev_tx.hash.should == "52250a162c7d03d2e1fbc5ebd1801a88612463314b55102171c5b5d817d2d7b2"
+      #File.open("rawtx-#{prev_tx.hash}.json",'wb'){|f| f.print prev_tx.to_json }
+    end
+
+    it "#legacy_sigops_count" do
+      Tx.new(@payload[0]).legacy_sigops_count.should == 2
+      Tx.new(@payload[1]).legacy_sigops_count.should == 2
+      Tx.new(@payload[2]).legacy_sigops_count.should == 2
+
+      # Test sig ops count in inputs too.
       tx = Tx.new
       txin = TxIn.new
-      txin.sequence = "\x01\x00\x00\x00"
+      txin.script_sig = Bitcoin::Script.from_string("10 OP_CHECKMULTISIGVERIFY OP_CHECKSIGVERIFY").to_binary
       tx.add_in(txin)
-      tx.lock_time = 6543
-      tx.is_final?(6000,0).should == false
-      tx.is_final?(6543,0).should == false # when equal to block height, still not final
-      tx.is_final?(6544,0).should == true
-      tx.is_final?(9999,0).should == true
+      txout = TxOut.new
+      txout.pk_script = Bitcoin::Script.from_string("5 OP_CHECKMULTISIG OP_CHECKSIG").to_binary
+      tx.add_out(txout)
+      tx.legacy_sigops_count.should == (20 + 1 + 20 + 1)
+
     end
-    
-    it "should be final if lock_time is below timestamp" do
-      tx = Tx.new
-      txin = TxIn.new
-      txin.sequence = "\xff\xff\xff\xff"
-      tx.add_in(txin)
-      txin = TxIn.new
-      txin.sequence = "\x01\x00\x00\x00"
-      tx.add_in(txin)
-      tx.lock_time = Bitcoin::LOCKTIME_THRESHOLD # when equal, interpreted as threshold
-      tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD - 1).should == false
-      tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD).should == false # when equal to timestamp, still not final
-      tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD + 1).should == true
-      
-      tx.lock_time = Bitcoin::LOCKTIME_THRESHOLD + 666
-      tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD + 1).should == false
-      tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD + 666).should == false # when equal to timestamp, still not final
-      tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD + 667).should == true
+
+    describe "Tx - is_final?" do
+      it "should be final if lock_time == 0" do
+        tx = Tx.new
+        tx.lock_time = 0
+        tx.is_final?(0,0).should == true
+
+        # even if has non-final input:
+        txin = TxIn.new
+        txin.sequence = "\x01\x00\x00\x00"
+        tx.add_in(txin)
+        tx.is_final?(0,0).should == true
+      end
+
+      it "should be final if lock_time is below block_height" do
+        tx = Tx.new
+        txin = TxIn.new
+        txin.sequence = "\x01\x00\x00\x00"
+        tx.add_in(txin)
+        tx.lock_time = 6543
+        tx.is_final?(6000,0).should == false
+        tx.is_final?(6543,0).should == false # when equal to block height, still not final
+        tx.is_final?(6544,0).should == true
+        tx.is_final?(9999,0).should == true
+      end
+
+      it "should be final if lock_time is below timestamp" do
+        tx = Tx.new
+        txin = TxIn.new
+        txin.sequence = "\xff\xff\xff\xff"
+        tx.add_in(txin)
+        txin = TxIn.new
+        txin.sequence = "\x01\x00\x00\x00"
+        tx.add_in(txin)
+        tx.lock_time = Bitcoin::LOCKTIME_THRESHOLD # when equal, interpreted as threshold
+        tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD - 1).should == false
+        tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD).should == false # when equal to timestamp, still not final
+        tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD + 1).should == true
+
+        tx.lock_time = Bitcoin::LOCKTIME_THRESHOLD + 666
+        tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD + 1).should == false
+        tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD + 666).should == false # when equal to timestamp, still not final
+        tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD + 667).should == true
+      end
+
+      it "should be final if all inputs are finalized regardless of lock_time" do
+        tx = Tx.new
+        txin = TxIn.new
+        txin.sequence = "\xff\xff\xff\xff"
+        tx.add_in(txin)
+        txin = TxIn.new
+        txin.sequence = "\xff\xff\xff\xff"
+        tx.add_in(txin)
+
+        tx.lock_time = 6543
+        tx.is_final?(6000,0).should == true
+        tx.is_final?(6543,0).should == true
+        tx.is_final?(6544,0).should == true
+        tx.is_final?(9999,0).should == true
+
+        tx.lock_time = Bitcoin::LOCKTIME_THRESHOLD
+        tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD - 1).should == true
+        tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD).should == true
+        tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD + 1).should == true
+
+        tx.lock_time = Bitcoin::LOCKTIME_THRESHOLD + 666
+        tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD + 1).should == true
+        tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD + 666).should == true
+        tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD + 667).should == true
+      end
+
     end
-    
-    it "should be final if all inputs are finalized regardless of lock_time" do
-      tx = Tx.new
-      txin = TxIn.new
-      txin.sequence = "\xff\xff\xff\xff"
-      tx.add_in(txin)
-      txin = TxIn.new
-      txin.sequence = "\xff\xff\xff\xff"
-      tx.add_in(txin)
-      
-      tx.lock_time = 6543
-      tx.is_final?(6000,0).should == true
-      tx.is_final?(6543,0).should == true
-      tx.is_final?(6544,0).should == true
-      tx.is_final?(9999,0).should == true
-      
-      tx.lock_time = Bitcoin::LOCKTIME_THRESHOLD
-      tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD - 1).should == true
-      tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD).should == true
-      tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD + 1).should == true
-      
-      tx.lock_time = Bitcoin::LOCKTIME_THRESHOLD + 666
-      tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD + 1).should == true
-      tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD + 666).should == true
-      tx.is_final?(0,Bitcoin::LOCKTIME_THRESHOLD + 667).should == true
+
+    it '#calculate_minimum_fee' do
+      tx = Tx.new( fixtures_file('rawtx-b5d4e8883533f99e5903ea2cf001a133a322fa6b1370b18a16c57c946a40823d.bin') )
+      tx.minimum_relay_fee.should == 0
+      tx.minimum_block_fee.should == 0
+      tx = Tx.from_json(fixtures_file('bc179baab547b7d7c1d5d8d6f8b0cc6318eaa4b0dd0a093ad6ac7f5a1cb6b3ba.json'))
+      tx.minimum_relay_fee.should == 0
+      tx.minimum_block_fee.should == 10_000
     end
-    
+
+    it '#calculate_minimum_fee for litecoin' do
+      tx = Tx.from_json(fixtures_file('litecoin-tx-f5aa30f574e3b6f1a3d99c07a6356ba812aabb9661e1d5f71edff828cbd5c996.json'))
+      tx.minimum_relay_fee.should == 0
+      tx.minimum_block_fee.should == 30_000
+      Bitcoin.network = :litecoin # change to litecoin
+      tx.minimum_relay_fee.should == 0
+      tx.minimum_block_fee.should == 5_900_000
+    end
+
+    it "should compare transactions" do
+      tx1 = Tx.new( @payload[0] )
+      tx2 = Tx.new( @payload[1] )
+      (tx1 == Bitcoin::P::Tx.from_json(tx1.to_json)).should == true
+      (tx1 == tx2).should == false
+      (tx1 == nil).should == false
+    end
+
+    describe "Tx - BIP Scripts" do
+
+      it "should do OP_CHECKMULTISIG" do
+        # checkmultisig without checkhashverify
+        tx = Tx.from_json(fixtures_file('23b397edccd3740a74adb603c9756370fafcde9bcc4483eb271ecad09a94dd63.json'))
+        prev_tx = Tx.from_json(fixtures_file('60a20bd93aa49ab4b28d514ec10b06e1829ce6818ec06cd3aabd013ebcdc4bb1.json'))
+        tx.verify_input_signature(0, prev_tx).should == true
+
+        # p2sh + multisig transaction from mainnet
+        tx      = Tx.from_json( fixtures_file('rawtx-ba1ff5cd66713133c062a871a8adab92416f1e38d17786b2bf56ac5f6ffdfdf5.json') )
+        prev_tx = Tx.from_json( fixtures_file("rawtx-de35d060663750b3975b7997bde7fb76307cec5b270d12fcd9c4ad98b279c28c.json") )
+        tx.verify_input_signature(0, prev_tx).should == true
+
+        # checkmultisig for testnet3 tx: 2c63aa814701cef5dbd4bbaddab3fea9117028f2434dddcdab8339141e9b14d1 input index 1
+        tx      = Tx.from_json( fixtures_file('tx-2c63aa814701cef5dbd4bbaddab3fea9117028f2434dddcdab8339141e9b14d1.json') )
+        prev_tx = Tx.from_json( fixtures_file("tx-19aa42fee0fa57c45d3b16488198b27caaacc4ff5794510d0c17f173f05587ff.json") )
+        tx.verify_input_signature(1, prev_tx).should == true
+      end
+
+      it "should do P2SH with inner OP_CHECKMULTISIG (BIP 0016)" do
+        tx = Tx.from_json(fixtures_file('3a17dace09ffb919ed627a93f1873220f4c975c1248558b18d16bce25d38c4b7.json'))
+        prev_tx = Tx.from_json(fixtures_file('35e2001b428891fefa0bfb73167c7360669d3cbd7b3aa78e7cad125ddfc51131.json'))
+        tx.verify_input_signature(0, prev_tx).should == true
+
+        tx = Tx.from_json(fixtures_file('bd1715f1abfdc62bea3f605bdb461b3ba1f2cca6ec0d73a18a548b7717ca8531.json'))
+        prev_tx = Tx.from_json(fixtures_file('ce5fad9b4ef094d8f4937b0707edaf0a6e6ceeaf67d5edbfd51f660eac8f398b.json'))
+        tx.verify_input_signature(1, prev_tx).should == true
+
+        # p2sh transaction with non-standard OP_CHECKMULTISIG inside found in testnet3 tx: d3d77d63709e47d9ef58f0b557800115a6b676c6a423012fbb96f45d8fcef830
+        tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-d3d77d63709e47d9ef58f0b557800115a6b676c6a423012fbb96f45d8fcef830.json'))
+        tx.hash.should == "d3d77d63709e47d9ef58f0b557800115a6b676c6a423012fbb96f45d8fcef830"
+        prev_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-313897799b1e37e9ecae15010e56156dddde4e683c96b0e713af95272c38aee0.json'))
+        prev_tx.hash.should == "313897799b1e37e9ecae15010e56156dddde4e683c96b0e713af95272c38aee0"
+        tx.verify_input_signature(0, prev_tx).should == true
+      end
+
+      it "should do P2SH with inner OP_CHECKSIG" do
+        # p2sh transaction with non-standard OP_CHECKSIG inside found in testnet3 tx: 3da75972766f0ad13319b0b461fd16823a731e44f6e9de4eb3c52d6a6fb6c8ae
+        tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-3da75972766f0ad13319b0b461fd16823a731e44f6e9de4eb3c52d6a6fb6c8ae.json'))
+        tx.hash.should == "3da75972766f0ad13319b0b461fd16823a731e44f6e9de4eb3c52d6a6fb6c8ae"
+        prev_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-44b833074e671120ba33106877b49e86ece510824b9af477a3853972bcd8d06a.json'))
+        prev_tx.hash.should == "44b833074e671120ba33106877b49e86ece510824b9af477a3853972bcd8d06a"
+        tx.verify_input_signature(0, prev_tx).should == true
+      end
+
+      it "should do OP_CHECKMULTISIG with OP_0 used as a pubkey" do
+        tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-6606c366a487bff9e412d0b6c09c14916319932db5954bf5d8719f43f828a3ba.json'))
+        tx.hash.should == "6606c366a487bff9e412d0b6c09c14916319932db5954bf5d8719f43f828a3ba"
+        prev_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-4142ee4877eb116abf955a7ec6ef2dc38133b793df762b76d75e3d7d4d8badc9.json'))
+        prev_tx.hash.should == "4142ee4877eb116abf955a7ec6ef2dc38133b793df762b76d75e3d7d4d8badc9"
+        tx.verify_input_signature(0, prev_tx).should == true
+      end
+
+    end
+
   end
-
-  it '#calculate_minimum_fee' do
-    tx = Tx.new( fixtures_file('rawtx-b5d4e8883533f99e5903ea2cf001a133a322fa6b1370b18a16c57c946a40823d.bin') )
-    tx.minimum_relay_fee.should == 0
-    tx.minimum_block_fee.should == 0
-    tx = Tx.from_json(fixtures_file('bc179baab547b7d7c1d5d8d6f8b0cc6318eaa4b0dd0a093ad6ac7f5a1cb6b3ba.json'))
-    tx.minimum_relay_fee.should == 0
-    tx.minimum_block_fee.should == 10_000
-  end
-
-  it '#calculate_minimum_fee for litecoin' do
-    tx = Tx.from_json(fixtures_file('litecoin-tx-f5aa30f574e3b6f1a3d99c07a6356ba812aabb9661e1d5f71edff828cbd5c996.json'))
-    tx.minimum_relay_fee.should == 0
-    tx.minimum_block_fee.should == 30_000
-    Bitcoin.network = :litecoin # change to litecoin
-    tx.minimum_relay_fee.should == 0
-    tx.minimum_block_fee.should == 5_900_000
-  end
-
-  it "should compare transactions" do
-    tx1 = Tx.new( @payload[0] )
-    tx2 = Tx.new( @payload[1] )
-    (tx1 == Bitcoin::P::Tx.from_json(tx1.to_json)).should == true
-    (tx1 == tx2).should == false
-    (tx1 == nil).should == false
-  end
-
-  describe "Tx - BIP Scripts" do
-
-    it "should do OP_CHECKMULTISIG" do
-      # checkmultisig without checkhashverify
-      tx = Tx.from_json(fixtures_file('23b397edccd3740a74adb603c9756370fafcde9bcc4483eb271ecad09a94dd63.json'))
-      prev_tx = Tx.from_json(fixtures_file('60a20bd93aa49ab4b28d514ec10b06e1829ce6818ec06cd3aabd013ebcdc4bb1.json'))
-      tx.verify_input_signature(0, prev_tx).should == true
-
-      # p2sh + multisig transaction from mainnet
-      tx      = Tx.from_json( fixtures_file('rawtx-ba1ff5cd66713133c062a871a8adab92416f1e38d17786b2bf56ac5f6ffdfdf5.json') )
-      prev_tx = Tx.from_json( fixtures_file("rawtx-de35d060663750b3975b7997bde7fb76307cec5b270d12fcd9c4ad98b279c28c.json") )
-      tx.verify_input_signature(0, prev_tx).should == true
-
-      # checkmultisig for testnet3 tx: 2c63aa814701cef5dbd4bbaddab3fea9117028f2434dddcdab8339141e9b14d1 input index 1
-      tx      = Tx.from_json( fixtures_file('tx-2c63aa814701cef5dbd4bbaddab3fea9117028f2434dddcdab8339141e9b14d1.json') )
-      prev_tx = Tx.from_json( fixtures_file("tx-19aa42fee0fa57c45d3b16488198b27caaacc4ff5794510d0c17f173f05587ff.json") )
-      tx.verify_input_signature(1, prev_tx).should == true
-    end
-
-    it "should do P2SH with inner OP_CHECKMULTISIG (BIP 0016)" do
-      tx = Tx.from_json(fixtures_file('3a17dace09ffb919ed627a93f1873220f4c975c1248558b18d16bce25d38c4b7.json'))
-      prev_tx = Tx.from_json(fixtures_file('35e2001b428891fefa0bfb73167c7360669d3cbd7b3aa78e7cad125ddfc51131.json'))
-      tx.verify_input_signature(0, prev_tx).should == true
-
-      tx = Tx.from_json(fixtures_file('bd1715f1abfdc62bea3f605bdb461b3ba1f2cca6ec0d73a18a548b7717ca8531.json'))
-      prev_tx = Tx.from_json(fixtures_file('ce5fad9b4ef094d8f4937b0707edaf0a6e6ceeaf67d5edbfd51f660eac8f398b.json'))
-      tx.verify_input_signature(1, prev_tx).should == true
-
-      # p2sh transaction with non-standard OP_CHECKMULTISIG inside found in testnet3 tx: d3d77d63709e47d9ef58f0b557800115a6b676c6a423012fbb96f45d8fcef830
-      tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-d3d77d63709e47d9ef58f0b557800115a6b676c6a423012fbb96f45d8fcef830.json'))
-      tx.hash.should == "d3d77d63709e47d9ef58f0b557800115a6b676c6a423012fbb96f45d8fcef830"
-      prev_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-313897799b1e37e9ecae15010e56156dddde4e683c96b0e713af95272c38aee0.json'))
-      prev_tx.hash.should == "313897799b1e37e9ecae15010e56156dddde4e683c96b0e713af95272c38aee0"
-      tx.verify_input_signature(0, prev_tx).should == true
-    end
-
-    it "should do P2SH with inner OP_CHECKSIG" do
-      # p2sh transaction with non-standard OP_CHECKSIG inside found in testnet3 tx: 3da75972766f0ad13319b0b461fd16823a731e44f6e9de4eb3c52d6a6fb6c8ae
-      tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-3da75972766f0ad13319b0b461fd16823a731e44f6e9de4eb3c52d6a6fb6c8ae.json'))
-      tx.hash.should == "3da75972766f0ad13319b0b461fd16823a731e44f6e9de4eb3c52d6a6fb6c8ae"
-      prev_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-44b833074e671120ba33106877b49e86ece510824b9af477a3853972bcd8d06a.json'))
-      prev_tx.hash.should == "44b833074e671120ba33106877b49e86ece510824b9af477a3853972bcd8d06a"
-      tx.verify_input_signature(0, prev_tx).should == true
-    end
-
-    it "should do OP_CHECKMULTISIG with OP_0 used as a pubkey" do
-      tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-6606c366a487bff9e412d0b6c09c14916319932db5954bf5d8719f43f828a3ba.json'))
-      tx.hash.should == "6606c366a487bff9e412d0b6c09c14916319932db5954bf5d8719f43f828a3ba"
-      prev_tx = Bitcoin::P::Tx.from_json(fixtures_file('tx-4142ee4877eb116abf955a7ec6ef2dc38133b793df762b76d75e3d7d4d8badc9.json'))
-      prev_tx.hash.should == "4142ee4877eb116abf955a7ec6ef2dc38133b793df762b76d75e3d7d4d8badc9"
-      tx.verify_input_signature(0, prev_tx).should == true
-    end
-
-  end
-  
 end

--- a/spec/bitcoin/protocol/txin_spec.rb
+++ b/spec/bitcoin/protocol/txin_spec.rb
@@ -2,44 +2,42 @@
 
 require_relative '../spec_helper.rb'
 
-include Bitcoin::Protocol
+module Bitcoin::Protocol
+  describe 'TxIn' do
 
-describe 'TxIn' do
-
-  describe '#initialize without specifying script_sig_length and script_sig' do
-    it 'still creates a serializable TxIn' do
-      prev_tx = Tx.new fixtures_file('rawtx-01.bin')
-      tx_in = TxIn.new prev_tx.binary_hash, 0
-      lambda { tx_in.to_payload }.should.not.raise
+    describe '#initialize without specifying script_sig_length and script_sig' do
+      it 'still creates a serializable TxIn' do
+        prev_tx = Tx.new fixtures_file('rawtx-01.bin')
+        tx_in = TxIn.new prev_tx.binary_hash, 0
+        lambda { tx_in.to_payload }.should.not.raise
+      end
     end
+
+    it "should compare txins" do
+      i1 = Tx.new(fixtures_file('rawtx-01.bin')).in[0]
+      i1_1 = TxIn.new(i1.prev_out, i1.prev_out_index, i1.script_sig_length, i1.script_sig)
+      i2 = Tx.new(fixtures_file('rawtx-02.bin')).in[0]
+
+      (i1 == i1).should == true
+      (i1 == i1_1).should == true
+      (i1 == i2).should == false
+      (i1 == nil).should == false
+    end
+
+    it "should be final only when sequence == 0xffffffff" do
+      txin = TxIn.new
+      txin.is_final?.should == true
+      txin.sequence.should == TxIn::DEFAULT_SEQUENCE
+
+      txin.sequence = "\x01\x00\x00\x00"
+      txin.is_final?.should == false
+
+      txin.sequence = "\x00\x00\x00\x00"
+      txin.is_final?.should == false
+
+      txin.sequence = "\xff\xff\xff\xff"
+      txin.is_final?.should == true
+    end
+
   end
-
-  it "should compare txins" do
-    i1 = Tx.new(fixtures_file('rawtx-01.bin')).in[0]
-    i1_1 = TxIn.new(i1.prev_out, i1.prev_out_index, i1.script_sig_length, i1.script_sig)
-    i2 = Tx.new(fixtures_file('rawtx-02.bin')).in[0]
-
-    (i1 == i1).should == true
-    (i1 == i1_1).should == true
-    (i1 == i2).should == false
-    (i1 == nil).should == false
-  end
-  
-  it "should be final only when sequence == 0xffffffff" do
-    txin = TxIn.new
-    txin.is_final?.should == true
-    txin.sequence.should == TxIn::DEFAULT_SEQUENCE
-    
-    txin.sequence = "\x01\x00\x00\x00"
-    txin.is_final?.should == false
-    
-    txin.sequence = "\x00\x00\x00\x00"
-    txin.is_final?.should == false
-
-    txin.sequence = "\xff\xff\xff\xff"
-    txin.is_final?.should == true
-  end
-  
-
 end
-

--- a/spec/bitcoin/protocol/txout_spec.rb
+++ b/spec/bitcoin/protocol/txout_spec.rb
@@ -2,26 +2,25 @@
 
 require_relative '../spec_helper.rb'
 
-include Bitcoin::Protocol
+module Bitcoin::Protocol
+  describe 'TxOut' do
 
-describe 'TxOut' do
+    it '#initialize without specifying script_sig_length' do
+      key = Bitcoin::Key.generate
+      tx_out = TxOut.new(12345, Bitcoin::Script.from_string("OP_DUP OP_HASH160 #{key.hash160} OP_EQUALVERIFY OP_CHECKSIG").to_payload)
+      lambda { tx_out.to_payload }.should.not.raise
+    end
 
-  it '#initialize without specifying script_sig_length' do
-    key = Bitcoin::Key.generate
-    tx_out = TxOut.new(12345, Bitcoin::Script.from_string("OP_DUP OP_HASH160 #{key.hash160} OP_EQUALVERIFY OP_CHECKSIG").to_payload)
-    lambda { tx_out.to_payload }.should.not.raise
+    it "should compare txouts" do
+      o1 = Tx.new(fixtures_file('rawtx-01.bin')).out[0]
+      o1_1 = TxOut.new(o1.value, o1.pk_script)
+      o2 = Tx.new(fixtures_file('rawtx-02.bin')).out[0]
+
+      (o1 == o1).should == true
+      (o1 == o1_1).should == true
+      (o1 == o2).should == false
+      (o1 == nil).should == false
+    end
+
   end
-
-  it "should compare txouts" do
-    o1 = Tx.new(fixtures_file('rawtx-01.bin')).out[0]
-    o1_1 = TxOut.new(o1.value, o1.pk_script)
-    o2 = Tx.new(fixtures_file('rawtx-02.bin')).out[0]
-
-    (o1 == o1).should == true
-    (o1 == o1_1).should == true
-    (o1 == o2).should == false
-    (o1 == nil).should == false
-  end
-
 end
-

--- a/spec/bitcoin/script/script_spec.rb
+++ b/spec/bitcoin/script/script_spec.rb
@@ -3,918 +3,918 @@
 require_relative '../spec_helper.rb'
 require 'bitcoin/script'
 
-include Bitcoin
-
-describe 'Bitcoin::Script' do
-  SCRIPT = [
-    "410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac",
-    "47304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901",
-    "76a91417977bca1b6287a5e6559c57ef4b6525e9d7ded688ac",
-    "524104573b6e9f3a714440048a7b87d606bcbf9e45b8586e70a67a3665ea720c095658471a523e5d923f3f3e015626e7c900bd08560ddffeb17d33c5b52c96edb875954104039c2f4e413a26901e67ad4adbb6a4759af87bc16c7120459ecc9482fed3dd4a4502947f7b4c7782dcadc2bed513ed14d5e770452b97ae246ac2030f13b80a5141048b0f9d04e495c3c754f8c3c109196d713d0778882ef098f785570ee6043f8c192d8f84df43ebafbcc168f5d95a074dc4010b62c003e560abc163c312966b74b653ae", # multisig 2 of 3
-    "5141040ee607b584b36e995f2e96dec35457dbb40845d0ce0782c84002134e816a6b8cbc65e9eed047ae05e10760e4113f690fd49ad73b86b04a1d7813d843f8690ace4104220a78f5f6741bb0739675c2cc200643516b02cfdfda5cba21edeaa62c0f954936b30dfd956e3e99af0a8e7665cff6ac5b429c54c418184c81fbcd4bde4088f552ae", # multisig 1 of 2
-    "a9149471864495192e39f5f74574b6c8c513588a820487", # p2sh
-    "6a04deadbeef" # OP_RETURN deadbeef
-  ].map{|s|[s].pack("H*")}
-  PUBKEYS = [
-    "04fb0123fe2c399981bc77d522e2ae3268d2ab15e9a84ae49338a4b1db3886a1ea04cdab955d81e9fa1fcb0c062cb9a5af1ad5dd5064f4afcca322402b07030ec2",
-    "0423b8161514560bc8638054b6637ab78f400b24e5694ec8061db635d1f28a17902b14dbf4f80780da659ab24f11ded3095c780452a4004c30ab58dffac33d839a",
-    "04f43e76afac66bf3927638b6c4f7e324513ce56d2d658ac9d24c420d09993a4464eea6141a68a4748c092ad0e8f4ac29c4a2f661ef4d22b21f20110f42fcd6f6d",
-  ]
-
-  describe "serialization" do
-    it '#to_string' do
-      Script.new(SCRIPT[0]).to_string.should ==
-        "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3 OP_CHECKSIG"
-
-      Script.new(SCRIPT[1]).to_string.should ==
-        "304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901"
-
-      #Script.new([123].pack("C")).to_string.should == "(opcode 123)"
-      Script.new([176].pack("C")).to_string.should == "OP_NOP1"
-      Script.from_string("1 OP_DROP 2").to_string.should == "1 OP_DROP 2"
-
-      Script.from_string("4b").to_string.should == "4b"
-      Script.from_string("4b").to_payload.should == "\x01\x4b"
-      Script.from_string("ff").to_string.should == "ff"
-      Script.from_string("ff").to_payload.should == "\x01\xff"
-      Script.from_string("ffff").to_string.should == "ffff"
-
-      Script.from_string( "ff"*(Script::OP_PUSHDATA1-1) ).to_payload[0]   .should == [Script::OP_PUSHDATA1-1].pack("C*")
-      Script.from_string( "ff"*Script::OP_PUSHDATA1     ).to_payload[0..1].should == [Script::OP_PUSHDATA1, Script::OP_PUSHDATA1].pack("C*")
-      Script.from_string( "ff"*(Script::OP_PUSHDATA1+1) ).to_payload[0..1].should == [Script::OP_PUSHDATA1, Script::OP_PUSHDATA1+1].pack("C*")
-      Script.from_string( "ff"*0xff                     ).to_payload[0..1].should == [Script::OP_PUSHDATA1, 0xff].pack("C*")
-      Script.from_string( "ff"*(0xff+1)                 ).to_payload[0..2].should == [Script::OP_PUSHDATA2, 0x00, 0x01].pack("C*")
-      Script.from_string( "ff"*0xffff                   ).to_payload[0..2].should == [Script::OP_PUSHDATA2, 0xff, 0xff].pack("C*")
-      Script.from_string( "ff"*(0xffff+1)               ).to_payload[0..4].should == [Script::OP_PUSHDATA4, 0x00, 0x00, 0x01, 0x00].pack("C*")
-
-      Script.from_string("16").to_string.should == "16"
-      Script::OP_2_16.include?(Script.from_string("16").chunks.first).should == true
-      Script.from_string("16").to_payload.should == "\x60"
-      Script.new("\x60").to_string.should == "16"
-
-      Script.from_string("0:1:16").to_string.should == "0:1:16"
-      Script::OP_2_16.include?(Script.from_string("0:1:16").chunks.first).should == false
-      Script.from_string("0:1:16").to_payload.should == "\x01\x16"
-      Script.new("\x01\x16").to_string.should == "0:1:16"
-
-      Script.new("\x4d\x01\x00\x02").to_string.should == "77:1:02"
-      Script.from_string("77:1:02").to_payload.should == "\x4d\x01\x00\x02"
-      Script.from_string("77:1:01").to_string.should == "77:1:01"
-      Script.from_string("77:2:0101").to_string.should == "77:2:0101"
-      Script.from_string("78:1:01").to_string.should == "78:1:01"
-      Script.from_string("78:2:0101").to_string.should == "78:2:0101"
-      Script.new("\x4e\x01\x00\x00\x00\x02").to_string.should == "78:1:02"
-      Script.from_string("78:1:02").to_payload.should == "\x4e\x01\x00\x00\x00\x02"
-
-      Script.new("\x4d\x01\x00").to_string.should == "77:1:"
-      Script.from_string("77:1:").to_payload.should == "\x4d\x01\x00"
-
-      [ # mainnet tx: ebc9fa1196a59e192352d76c0f6e73167046b9d37b8302b6bb6968dfd279b767 outputs
-        ["\x01",                        "238:1:01",            true],
-        ["\x02\x01",                    "238:2:0201",          true],
-        ["L",                           "238:1:4c",            true],
-        ["L\x02\x01",                   "76:2:01",              nil],
-        ["M",                           "238:1:4d",            true],
-        ["M\xff\xff\x01",               "238:4:4dffff01",      true],
-        ["N",                           "238:1:4e",            true],
-        ["N\xff\xff\xff\xff\x01",       "238:6:4effffffff01",  true],
-      ].each{|payload,string,parse_invalid|
-        Script.new(payload).to_string.should == string
-        Script.new(payload).instance_eval{ @parse_invalid }.should == parse_invalid
-        Script.from_string(string).to_payload == payload
-      }
-
-      Bitcoin::Script.from_string("(opcode-230) 4 1 2").to_string.should == "(opcode-230) 4 1 2"
-      Bitcoin::Script.from_string("(opcode 230) 4 1 2").to_string.should == "(opcode-230) 4 1 2"
-      Bitcoin::Script.from_string("(opcode-65449) 4 1 2").to_string.should == "OP_INVALIDOPCODE OP_HASH160 4 1 2"
-
-      # found in testnet3 block 0000000000ac85bb2530a05a4214a387e6be02b22d3348abc5e7a5d9c4ce8dab transactions
-      Script.new("\xff\xff\xff\xff").to_string.should == "OP_INVALIDOPCODE OP_INVALIDOPCODE OP_INVALIDOPCODE OP_INVALIDOPCODE"
-      Script.from_string(Script.new("\xff\xff\xff\xff").to_string).raw.should == "\xFF\xFF\xFF\xFF"
-      Script.new("\xff\xff\xff").to_string.should == "OP_INVALIDOPCODE OP_INVALIDOPCODE OP_INVALIDOPCODE"
-      Script.from_string(Script.new("\xff\xff\xff").to_string).raw.should == "\xFF\xFF\xFF"
-    end
-
-    it 'Script#binary_from_string' do
-      str = Script.new(SCRIPT[0]).to_string
-      Script.binary_from_string(str).unpack("H*")[0].should == SCRIPT[0].unpack("H*")[0]
-      Script.new(Script.binary_from_string(str)).to_string.should == str
-
-      str = Script.new(SCRIPT[1]).to_string
-      Script.binary_from_string(str).unpack("H*")[0].should == SCRIPT[1].unpack("H*")[0]
-      Script.new(Script.binary_from_string(str)).to_string.should == str
-      # TODO make tests for OP_PUSHDATA1, OP_PUSHDATA2, OP_PUSHDATA4 cases
-
-      string = "2 OP_TOALTSTACK 0 OP_TOALTSTACK OP_TUCK OP_CHECKSIG OP_SWAP OP_HASH160 3cd1def404e12a85ead2b4d3f5f9f817fb0d46ef OP_EQUAL OP_BOOLAND OP_FROMALTSTACK OP_ADD"
-      Script.from_string(string).to_string.should == string
-
-      Script.from_string("0 OP_DROP 2 3 4").to_string.should == "0 OP_DROP 2 3 4"
-
-      Script.from_string("OP_EVAL").to_string.should == "OP_NOP1"
-      Script.from_string("OP_NOP1").to_string.should == "OP_NOP1" # test opcodes_alias table
-      Script.from_string("OP_NOP").to_string.should == "OP_NOP"
-      Script.from_string("1").to_string.should == "1"
-
-      Script.from_string("0 ffff OP_CODESEPARATOR 1 ffff 1 OP_CHECKMULTISIG").to_string.should == "0 ffff OP_CODESEPARATOR 1 ffff 1 OP_CHECKMULTISIG"
-
-      [1,2,4].all?{|n| script = "OP_PUSHDATA#{n} 01 ff"
-        Bitcoin::Script.binary_from_string(script) == Bitcoin::Script.binary_from_string( Bitcoin::Script.from_string(script).to_string )
-      }.should == true
-
-      #Script.from_string("-100").to_string.should == "OP_NOP"
-      #Script.from_string("100").to_string.should == "100"
-
-      proc{ Script.from_string("OP_NOP OP_UNKOWN") }.should.raise(Script::ScriptOpcodeError).message.should == "OP_UNKOWN not defined!"
-    end
-  end
-
-  describe "get keys/addresses" do
-    it '#get_pubkey' do
-      Script.new(SCRIPT[0]).get_pubkey.should ==
-        "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3"
-    end
-
-    it '#get_pubkey_address' do
-      Script.new(SCRIPT[0]).get_pubkey_address.should ==
-        "12cbQLTFMXRnSzktFkuoG3eHoMeFtpTu3S"
-    end
-
-    it "#get_hash160" do
-      Script.new(SCRIPT[2]).get_hash160.should ==
-        "17977bca1b6287a5e6559c57ef4b6525e9d7ded6"
-      Script.from_string("OP_DUP OP_HASH160 0 OP_EQUALVERIFY OP_CHECKSIG")
-        .get_hash160.should == nil
-    end
-
-    it "#get_hash160_address" do
-      Script.new(SCRIPT[2]).get_hash160_address.should ==
-        "139k1g5rtTsL4aGZbcASH3Fv3fUh9yBEdW"
-    end
-
-    it "#get_multisig_pubkeys" do
-      Script.new(SCRIPT[3]).get_multisig_pubkeys.should == [
-        "04573b6e9f3a714440048a7b87d606bcbf9e45b8586e70a67a3665ea720c095658471a523e5d923f3f3e015626e7c900bd08560ddffeb17d33c5b52c96edb87595",
-        "04039c2f4e413a26901e67ad4adbb6a4759af87bc16c7120459ecc9482fed3dd4a4502947f7b4c7782dcadc2bed513ed14d5e770452b97ae246ac2030f13b80a51",
-        "048b0f9d04e495c3c754f8c3c109196d713d0778882ef098f785570ee6043f8c192d8f84df43ebafbcc168f5d95a074dc4010b62c003e560abc163c312966b74b6"].map{|pk| [pk].pack("H*")}
-      Script.from_string("3 #{PUBKEYS[0..2].join(' ')} 3 OP_CHECKMULTISIG")
-        .get_multisig_pubkeys.should == [
-        "04fb0123fe2c399981bc77d522e2ae3268d2ab15e9a84ae49338a4b1db3886a1ea04cdab955d81e9fa1fcb0c062cb9a5af1ad5dd5064f4afcca322402b07030ec2",
-        "0423b8161514560bc8638054b6637ab78f400b24e5694ec8061db635d1f28a17902b14dbf4f80780da659ab24f11ded3095c780452a4004c30ab58dffac33d839a",
-        "04f43e76afac66bf3927638b6c4f7e324513ce56d2d658ac9d24c420d09993a4464eea6141a68a4748c092ad0e8f4ac29c4a2f661ef4d22b21f20110f42fcd6f6d"].map{|k|[k].pack("H*")}
-    end
-
-    it "#get_multisig_addresses" do
-      Script.new(SCRIPT[3]).get_multisig_addresses.should == [
-        "1JiaVc3N3U3CwwcLtzNX1Q4eYfeYxVjtuj", "19Fm2gY7qDTXriNTEhFY2wjxbHna3Gvenk",
-        "1B6k6g1d2L975i7beAbiBRxfBWhxomPxvy"]
-      Script.new(SCRIPT[4]).get_multisig_addresses.should == [
-        "1F2Nnyn7niMcheiYhkHrkc18aDxEkFowy5", "1EE7JGimkV7QqyHwXDJvk3b1yEN4ZUWeqx"]
-
-      # from tx 274f8be3b7b9b1a220285f5f71f61e2691dd04df9d69bb02a8b3b85f91fb1857, second pubkey has invalid encoding.
-      output = "1 0351efb6e91a31221652105d032a2508275f374cea63939ad72f1b1e02f477da78 00f2b7816db49d55d24df7bdffdbc1e203b424e8cd39f5651ab938e5e4a193569e 2 OP_CHECKMULTISIG"
-      Bitcoin::Script.from_string(output).get_multisig_addresses.should == ["1NdB761LmTmrJixxp93nz7pEiCx5cKPW44"]
-    end
-
-    it "#get_p2sh_address" do
-      Script.new(SCRIPT[5]).get_p2sh_address.should ==
-        "3FDuvkgzsW7LpzL9RBjtjvL7bFXCEeZ7xi"
-    end
-
-    it "#get_address" do
-      Script.new(SCRIPT[0]).get_address.should ==
-        "12cbQLTFMXRnSzktFkuoG3eHoMeFtpTu3S"
-      Script.new(SCRIPT[1]).get_address.should == nil
-      Script.new(SCRIPT[2]).get_address.should ==
-        "139k1g5rtTsL4aGZbcASH3Fv3fUh9yBEdW"
-      Script.new(SCRIPT[3]).get_address.should ==
-        "1JiaVc3N3U3CwwcLtzNX1Q4eYfeYxVjtuj"
-      Script.new(SCRIPT[4]).get_address.should ==
-        "1F2Nnyn7niMcheiYhkHrkc18aDxEkFowy5"
-      Script.new(SCRIPT[5]).get_address.should ==
-        "3FDuvkgzsW7LpzL9RBjtjvL7bFXCEeZ7xi"
-    end
-
-    it "#get_addresses" do
-      Script.new(SCRIPT[0]).get_addresses.
-        should == ["12cbQLTFMXRnSzktFkuoG3eHoMeFtpTu3S"]
-      Script.new(SCRIPT[3]).get_addresses
-        .should == ["1JiaVc3N3U3CwwcLtzNX1Q4eYfeYxVjtuj",
-        "19Fm2gY7qDTXriNTEhFY2wjxbHna3Gvenk", "1B6k6g1d2L975i7beAbiBRxfBWhxomPxvy"]
-    end
-
-    it "should get op_return data" do
-      Script.new(SCRIPT[6]).get_op_return_data.should == "deadbeef"
-      Script.new(SCRIPT[1]).get_op_return_data.should == nil
-      Script.from_string("OP_RETURN").get_op_return_data.should == nil
-      Script.from_string("OP_RETURN dead beef").get_op_return_data.should == nil
-      Script.from_string("OP_RETURN deadbeef").get_op_return_data.should == "deadbeef"
-      Script.from_string("OP_RETURN OP_CHECKSIG").get_op_return_data.should == "ac00"
-    end
-
-  end
-
-  describe "determine type" do
-
-    it '#is_standard?' do
-      Script.new(SCRIPT[0]).is_standard?.should == true
-      Script.new(SCRIPT[1]).is_standard?.should == false
-      Script.new(SCRIPT[2]).is_standard?.should == true
-      Script.new(SCRIPT[3]).is_standard?.should == true
-      Script.new(SCRIPT[4]).is_standard?.should == true
-      Script.new(SCRIPT[5]).is_standard?.should == true
-      Script.new(SCRIPT[6]).is_standard?.should == true
-    end
-
-    it '#is_pubkey?' do
-      Script.new(SCRIPT[0]).is_pubkey?.should == true
-      Script.new(SCRIPT[1]).is_pubkey?.should == false
-      Script.new(SCRIPT[2]).is_pubkey?.should == false
-      Script.new(SCRIPT[3]).is_pubkey?.should == false
-      Script.new(SCRIPT[4]).is_send_to_ip?.should == false
-      Script.new(SCRIPT[5]).is_pubkey?.should == false
-      Script.new(SCRIPT[6]).is_pubkey?.should == false
-      Script.from_string("0 OP_CHECKSIG").is_pubkey?.should == false # testnet aba0441c4c9933dcd7db789c39053739ec435ab742ed2c23c05f22f1488c0bfd
-    end
-
-    it "#is_hash160?" do
-      Script.new(SCRIPT[0]).is_hash160?.should == false
-      Script.new(SCRIPT[1]).is_pubkey?.should == false
-      Script.new(SCRIPT[2]).is_hash160?.should == true
-      Script.from_string("OP_DUP OP_HASH160 0 OP_EQUALVERIFY OP_CHECKSIG")
-        .is_hash160?.should == false
-      Script.new(SCRIPT[5]).is_hash160?.should == false
-      Script.new(SCRIPT[6]).is_hash160?.should == false
-    end
-
-    it "#is_multisig?" do
-      Script.new(SCRIPT[3]).is_multisig?.should == true
-      Script.new(SCRIPT[4]).is_multisig?.should == true
-      Script.new(SCRIPT[0]).is_multisig?.should == false
-      Script.new(SCRIPT[6]).is_multisig?.should == false
-      Script.new("OP_DUP OP_DROP 2 #{PUBKEYS[0..2].join(' ')} 3 OP_CHECKMULTISIG")
-        .is_multisig?.should == false
-      Script.new("OP_DROP OP_CHECKMULTISIG").is_multisig?.should == false
-      Script.from_string("d366fb5cbf048801b1bf0742bb0d873f65afb406f41756bd4a31865870f6a928 OP_DROP 2 02aae4b5cd593da83679a9c5cadad4c180c008a40dd3ed240cceb2933b9912da36 03a5aebd8b1b6eec06abc55fb13c72a9ed2143f9eed7d665970e38853d564bf1ab OP_CHECKMULTISIG").is_multisig?.should == false
-    end
-
-    it '#is_p2sh?' do
-      Script.new(SCRIPT[0]).is_p2sh?.should == false
-      Script.new(SCRIPT[1]).is_p2sh?.should == false
-      Script.new(SCRIPT[2]).is_p2sh?.should == false
-      Script.new(SCRIPT[3]).is_p2sh?.should == false
-      Script.new(SCRIPT[4]).is_p2sh?.should == false
-      Script.new(SCRIPT[5]).is_p2sh?.should == true
-      Script.new(SCRIPT[6]).is_p2sh?.should == false
-      Script.from_string("OP_DUP OP_HASH160 b689ebc262f50297139e7d16c4f8909e14ed4322 OP_EQUALVERIFY OP_CHECKSIGVERIFY OP_HASH160 1b6246121883816fc0637e4aa280aca1df219b1a OP_EQUAL")
-        .is_p2sh?.should == false
-    end
-
-    it '#is_op_return?' do
-      Script.new(SCRIPT[0]).is_op_return?.should == false
-      Script.new(SCRIPT[1]).is_op_return?.should == false
-      Script.new(SCRIPT[2]).is_op_return?.should == false
-      Script.new(SCRIPT[3]).is_op_return?.should == false
-      Script.new(SCRIPT[4]).is_op_return?.should == false
-      Script.new(SCRIPT[5]).is_op_return?.should == false
-      Script.new(SCRIPT[6]).is_op_return?.should == true
-      Script.from_string("OP_RETURN dead beef").is_op_return?.should == false
-      Script.from_string("OP_RETURN deadbeef").is_op_return?.should == true
-      Script.from_string("OP_RETURN OP_CHECKSIG").is_op_return?.should == true
-    end
-
-    it "#type" do
-      Script.new(SCRIPT[0]).type.should == :pubkey
-      Script.new(SCRIPT[1]).type.should == :unknown
-      Script.new(SCRIPT[2]).type.should == :hash160
-      Script.new(SCRIPT[3]).type.should == :multisig
-      Script.new(SCRIPT[4]).type.should == :multisig
-      Script.new(SCRIPT[5]).type.should == :p2sh
-      Script.new(SCRIPT[6]).type.should == :op_return
-      Script.from_string("OP_RETURN OP_CHECKSIG").type.should == :op_return
-      Script.from_string("OP_RETURN dead beef").type.should == :unknown
-    end
-
-  end
-
-  describe "generate scripts" do
-
-    it "should generate pubkey script" do
-      Script.to_pubkey_script(PUBKEYS[0]).should ==
-        Script.from_string("#{PUBKEYS[0]} OP_CHECKSIG").raw
-      Script.to_pubkey_script(PUBKEYS[1]).should ==
-        Script.from_string("#{PUBKEYS[1]} OP_CHECKSIG").raw
-    end
-
-    it "should generate hash160 script" do
-      Script.to_address_script('16Tc7znw2mfpWcqS84vBFfJ7PyoeHaXSz9')
-        .should == ["76a9143be0c2daaabbf3d53e47352c19d1e8f047e2f94188ac"].pack("H*")
-      hash160 = Bitcoin.hash160_from_address('16Tc7znw2mfpWcqS84vBFfJ7PyoeHaXSz9')
-      Script.to_hash160_script(hash160)
-        .should == Script.from_string("OP_DUP OP_HASH160 #{hash160} OP_EQUALVERIFY OP_CHECKSIG").raw
-      Script.to_address_script('mr1jU3Adw2pkvxTLvQA4MKpXB9Dynj9cXF')
-        .should == nil
-    end
-
-    it "should generate multisig script" do
-      Script.to_multisig_script(2, *PUBKEYS[0..2]).should ==
-        Script.from_string("2 #{PUBKEYS[0..2].join(' ')} 3 OP_CHECKMULTISIG").raw
-      Script.to_multisig_script(1, *PUBKEYS[0..1]).should ==
-        Script.from_string("1 #{PUBKEYS[0..1].join(' ')} 2 OP_CHECKMULTISIG").raw
-
-      m=n=16; Bitcoin::Script.new(Bitcoin::Script.to_multisig_script(m, *(["a"]*n))).to_string
-        .should == "16 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 16 OP_CHECKMULTISIG"
-      m=n=17; Bitcoin::Script.new(Bitcoin::Script.to_multisig_script(m, *(["a"]*n))).to_string
-        .should == "0:1:11 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 0:1:11 OP_CHECKMULTISIG"
-      m=n=20; Bitcoin::Script.new(Bitcoin::Script.to_multisig_script(m, *(["a"]*n))).to_string
-        .should == "0:1:14 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 0:1:14 OP_CHECKMULTISIG"
-    end
-
-    it "should generate p2sh script" do
-      address = "3CkxTG25waxsmd13FFgRChPuGYba3ar36B"
-      hash160 = Bitcoin.hash160_from_address address
-      Script.to_p2sh_script(hash160).should ==
-        Script.from_string("OP_HASH160 #{hash160} OP_EQUAL").raw
-    end
-
-    it "should generate op_return script" do
-      Script.to_op_return_script("deadbeef").should == SCRIPT[6]
-      Script.to_op_return_script.should == Script.from_string("OP_RETURN").raw
-    end
-
-    it "should determine type for address script" do
-      address = '16Tc7znw2mfpWcqS84vBFfJ7PyoeHaXSz9'
-      hash160 = Bitcoin.hash160_from_address address
-      Script.to_address_script(address).should ==
-        Script.from_string("OP_DUP OP_HASH160 #{hash160} OP_EQUALVERIFY OP_CHECKSIG").raw
-
-      address = "3CkxTG25waxsmd13FFgRChPuGYba3ar36B"
-      hash160 = Bitcoin.hash160_from_address address
-      Script.to_p2sh_script(hash160).should ==
-        Script.from_string("OP_HASH160 #{hash160} OP_EQUAL").raw
-    end
-
-  end
-
-  describe "generate script sigs" do
-    before do
-      @sig = '3045022062437a8f60651cd968137355775fa8bdb83d4ca717fdbc08bf9868a051e0542f022100f5cd626c15ef0de0803ddf299e8895743e7ff484d6335874edfe086ee0a08fec'.htb
-    end
-
-    it "should generate pubkey script sig" do
-      pub = '04bc3e2b520d4be3e2651f2ba554392ea31edd69d2081186ab98acda3c4bf45e41a5f6e093277b774b5893347e38ffafce2b9e82226e6e0b378cf79b8c2eed983c'.htb
-      expected_script = '483045022062437a8f60651cd968137355775fa8bdb83d4ca717fdbc08bf9868a051e0542f022100f5cd626c15ef0de0803ddf299e8895743e7ff484d6335874edfe086ee0a08fec014104bc3e2b520d4be3e2651f2ba554392ea31edd69d2081186ab98acda3c4bf45e41a5f6e093277b774b5893347e38ffafce2b9e82226e6e0b378cf79b8c2eed983c'.htb
-
-      Script.to_pubkey_script_sig(@sig, pub).should == expected_script
-    end
-
-    it "should accept a compressed public key as input" do
-      pub = '02bc3e2b520d4be3e2651f2ba554392ea31edd69d2081186ab98acda3c4bf45e41'.htb
-      expected_script = '483045022062437a8f60651cd968137355775fa8bdb83d4ca717fdbc08bf9868a051e0542f022100f5cd626c15ef0de0803ddf299e8895743e7ff484d6335874edfe086ee0a08fec012102bc3e2b520d4be3e2651f2ba554392ea31edd69d2081186ab98acda3c4bf45e41'.htb
-
-      Script.to_pubkey_script_sig(@sig, pub).should == expected_script
-    end
-
-    it "should reject an improperly encoding public key" do
-      # Not binary encoded, like it's supposed to be.
-      pub = '02bc3e2b520d4be3e2651f2ba554392ea31edd69d2081186ab98acda3c4bf45e41'
-
-      lambda {
-        Script.to_pubkey_script_sig(@sig, pub)
-      }.should.raise
-    end
-
-    it "should support different hash types" do
-      hash_type = Script::SIGHASH_TYPE[:single]
-      pub = '04bc3e2b520d4be3e2651f2ba554392ea31edd69d2081186ab98acda3c4bf45e41a5f6e093277b774b5893347e38ffafce2b9e82226e6e0b378cf79b8c2eed983c'.htb
-      expected_script = '483045022062437a8f60651cd968137355775fa8bdb83d4ca717fdbc08bf9868a051e0542f022100f5cd626c15ef0de0803ddf299e8895743e7ff484d6335874edfe086ee0a08fec034104bc3e2b520d4be3e2651f2ba554392ea31edd69d2081186ab98acda3c4bf45e41a5f6e093277b774b5893347e38ffafce2b9e82226e6e0b378cf79b8c2eed983c'.htb
-
-      Script.to_pubkey_script_sig(@sig, pub, hash_type).should == expected_script
-    end
-
-    it "should generate multisig script sig" do
-      hash_type = Script::SIGHASH_TYPE[:none]
-      expected_script = '00483045022062437a8f60651cd968137355775fa8bdb83d4ca717fdbc08bf9868a051e0542f022100f5cd626c15ef0de0803ddf299e8895743e7ff484d6335874edfe086ee0a08fec02483045022062437a8f60651cd968137355775fa8bdb83d4ca717fdbc08bf9868a051e0542f022100f5cd626c15ef0de0803ddf299e8895743e7ff484d6335874edfe086ee0a08fec02'.htb
-
-      Script.to_multisig_script_sig(@sig, @sig, hash_type).should == expected_script
-    end
-  end
-
-
-  describe "signatures_count" do
-
-    it "should be zero in data-only scripts" do
-      [false, true].each do |accurate|
-        Script.from_string("").sigops_count_accurate(accurate).should == 0
-        Script.from_string("DEADBEEF").sigops_count_accurate(accurate).should == 0
-        Script.from_string("DEAD BEEF").sigops_count_accurate(accurate).should == 0
-        Script.from_string("DE AD BE EF").sigops_count_accurate(accurate).should == 0
-        Script.from_string("OP_NOP").sigops_count_accurate(accurate).should == 0
-        Script.from_string("0").sigops_count_accurate(accurate).should == 0
-        Script.from_string("0 1").sigops_count_accurate(accurate).should == 0
-        Script.from_string("0 1 2 3").sigops_count_accurate(accurate).should == 0
+module Bitcoin
+  describe 'Bitcoin::Script' do
+    SCRIPT = [
+      "410411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3ac",
+      "47304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901",
+      "76a91417977bca1b6287a5e6559c57ef4b6525e9d7ded688ac",
+      "524104573b6e9f3a714440048a7b87d606bcbf9e45b8586e70a67a3665ea720c095658471a523e5d923f3f3e015626e7c900bd08560ddffeb17d33c5b52c96edb875954104039c2f4e413a26901e67ad4adbb6a4759af87bc16c7120459ecc9482fed3dd4a4502947f7b4c7782dcadc2bed513ed14d5e770452b97ae246ac2030f13b80a5141048b0f9d04e495c3c754f8c3c109196d713d0778882ef098f785570ee6043f8c192d8f84df43ebafbcc168f5d95a074dc4010b62c003e560abc163c312966b74b653ae", # multisig 2 of 3
+      "5141040ee607b584b36e995f2e96dec35457dbb40845d0ce0782c84002134e816a6b8cbc65e9eed047ae05e10760e4113f690fd49ad73b86b04a1d7813d843f8690ace4104220a78f5f6741bb0739675c2cc200643516b02cfdfda5cba21edeaa62c0f954936b30dfd956e3e99af0a8e7665cff6ac5b429c54c418184c81fbcd4bde4088f552ae", # multisig 1 of 2
+      "a9149471864495192e39f5f74574b6c8c513588a820487", # p2sh
+      "6a04deadbeef" # OP_RETURN deadbeef
+    ].map{|s|[s].pack("H*")}
+    PUBKEYS = [
+      "04fb0123fe2c399981bc77d522e2ae3268d2ab15e9a84ae49338a4b1db3886a1ea04cdab955d81e9fa1fcb0c062cb9a5af1ad5dd5064f4afcca322402b07030ec2",
+      "0423b8161514560bc8638054b6637ab78f400b24e5694ec8061db635d1f28a17902b14dbf4f80780da659ab24f11ded3095c780452a4004c30ab58dffac33d839a",
+      "04f43e76afac66bf3927638b6c4f7e324513ce56d2d658ac9d24c420d09993a4464eea6141a68a4748c092ad0e8f4ac29c4a2f661ef4d22b21f20110f42fcd6f6d",
+    ]
+
+    describe "serialization" do
+      it '#to_string' do
+        Script.new(SCRIPT[0]).to_string.should ==
+          "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3 OP_CHECKSIG"
+
+        Script.new(SCRIPT[1]).to_string.should ==
+          "304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901"
+
+        #Script.new([123].pack("C")).to_string.should == "(opcode 123)"
+        Script.new([176].pack("C")).to_string.should == "OP_NOP1"
+        Script.from_string("1 OP_DROP 2").to_string.should == "1 OP_DROP 2"
+
+        Script.from_string("4b").to_string.should == "4b"
+        Script.from_string("4b").to_payload.should == "\x01\x4b"
+        Script.from_string("ff").to_string.should == "ff"
+        Script.from_string("ff").to_payload.should == "\x01\xff"
+        Script.from_string("ffff").to_string.should == "ffff"
+
+        Script.from_string( "ff"*(Script::OP_PUSHDATA1-1) ).to_payload[0]   .should == [Script::OP_PUSHDATA1-1].pack("C*")
+        Script.from_string( "ff"*Script::OP_PUSHDATA1     ).to_payload[0..1].should == [Script::OP_PUSHDATA1, Script::OP_PUSHDATA1].pack("C*")
+        Script.from_string( "ff"*(Script::OP_PUSHDATA1+1) ).to_payload[0..1].should == [Script::OP_PUSHDATA1, Script::OP_PUSHDATA1+1].pack("C*")
+        Script.from_string( "ff"*0xff                     ).to_payload[0..1].should == [Script::OP_PUSHDATA1, 0xff].pack("C*")
+        Script.from_string( "ff"*(0xff+1)                 ).to_payload[0..2].should == [Script::OP_PUSHDATA2, 0x00, 0x01].pack("C*")
+        Script.from_string( "ff"*0xffff                   ).to_payload[0..2].should == [Script::OP_PUSHDATA2, 0xff, 0xff].pack("C*")
+        Script.from_string( "ff"*(0xffff+1)               ).to_payload[0..4].should == [Script::OP_PUSHDATA4, 0x00, 0x00, 0x01, 0x00].pack("C*")
+
+        Script.from_string("16").to_string.should == "16"
+        Script::OP_2_16.include?(Script.from_string("16").chunks.first).should == true
+        Script.from_string("16").to_payload.should == "\x60"
+        Script.new("\x60").to_string.should == "16"
+
+        Script.from_string("0:1:16").to_string.should == "0:1:16"
+        Script::OP_2_16.include?(Script.from_string("0:1:16").chunks.first).should == false
+        Script.from_string("0:1:16").to_payload.should == "\x01\x16"
+        Script.new("\x01\x16").to_string.should == "0:1:16"
+
+        Script.new("\x4d\x01\x00\x02").to_string.should == "77:1:02"
+        Script.from_string("77:1:02").to_payload.should == "\x4d\x01\x00\x02"
+        Script.from_string("77:1:01").to_string.should == "77:1:01"
+        Script.from_string("77:2:0101").to_string.should == "77:2:0101"
+        Script.from_string("78:1:01").to_string.should == "78:1:01"
+        Script.from_string("78:2:0101").to_string.should == "78:2:0101"
+        Script.new("\x4e\x01\x00\x00\x00\x02").to_string.should == "78:1:02"
+        Script.from_string("78:1:02").to_payload.should == "\x4e\x01\x00\x00\x00\x02"
+
+        Script.new("\x4d\x01\x00").to_string.should == "77:1:"
+        Script.from_string("77:1:").to_payload.should == "\x4d\x01\x00"
+
+        [ # mainnet tx: ebc9fa1196a59e192352d76c0f6e73167046b9d37b8302b6bb6968dfd279b767 outputs
+          ["\x01",                        "238:1:01",            true],
+          ["\x02\x01",                    "238:2:0201",          true],
+          ["L",                           "238:1:4c",            true],
+          ["L\x02\x01",                   "76:2:01",              nil],
+          ["M",                           "238:1:4d",            true],
+          ["M\xff\xff\x01",               "238:4:4dffff01",      true],
+          ["N",                           "238:1:4e",            true],
+          ["N\xff\xff\xff\xff\x01",       "238:6:4effffffff01",  true],
+        ].each{|payload,string,parse_invalid|
+          Script.new(payload).to_string.should == string
+          Script.new(payload).instance_eval{ @parse_invalid }.should == parse_invalid
+          Script.from_string(string).to_payload == payload
+        }
+
+        Bitcoin::Script.from_string("(opcode-230) 4 1 2").to_string.should == "(opcode-230) 4 1 2"
+        Bitcoin::Script.from_string("(opcode 230) 4 1 2").to_string.should == "(opcode-230) 4 1 2"
+        Bitcoin::Script.from_string("(opcode-65449) 4 1 2").to_string.should == "OP_INVALIDOPCODE OP_HASH160 4 1 2"
+
+        # found in testnet3 block 0000000000ac85bb2530a05a4214a387e6be02b22d3348abc5e7a5d9c4ce8dab transactions
+        Script.new("\xff\xff\xff\xff").to_string.should == "OP_INVALIDOPCODE OP_INVALIDOPCODE OP_INVALIDOPCODE OP_INVALIDOPCODE"
+        Script.from_string(Script.new("\xff\xff\xff\xff").to_string).raw.should == "\xFF\xFF\xFF\xFF"
+        Script.new("\xff\xff\xff").to_string.should == "OP_INVALIDOPCODE OP_INVALIDOPCODE OP_INVALIDOPCODE"
+        Script.from_string(Script.new("\xff\xff\xff").to_string).raw.should == "\xFF\xFF\xFF"
+      end
+
+      it 'Script#binary_from_string' do
+        str = Script.new(SCRIPT[0]).to_string
+        Script.binary_from_string(str).unpack("H*")[0].should == SCRIPT[0].unpack("H*")[0]
+        Script.new(Script.binary_from_string(str)).to_string.should == str
+
+        str = Script.new(SCRIPT[1]).to_string
+        Script.binary_from_string(str).unpack("H*")[0].should == SCRIPT[1].unpack("H*")[0]
+        Script.new(Script.binary_from_string(str)).to_string.should == str
+        # TODO make tests for OP_PUSHDATA1, OP_PUSHDATA2, OP_PUSHDATA4 cases
+
+        string = "2 OP_TOALTSTACK 0 OP_TOALTSTACK OP_TUCK OP_CHECKSIG OP_SWAP OP_HASH160 3cd1def404e12a85ead2b4d3f5f9f817fb0d46ef OP_EQUAL OP_BOOLAND OP_FROMALTSTACK OP_ADD"
+        Script.from_string(string).to_string.should == string
+
+        Script.from_string("0 OP_DROP 2 3 4").to_string.should == "0 OP_DROP 2 3 4"
+
+        Script.from_string("OP_EVAL").to_string.should == "OP_NOP1"
+        Script.from_string("OP_NOP1").to_string.should == "OP_NOP1" # test opcodes_alias table
+        Script.from_string("OP_NOP").to_string.should == "OP_NOP"
+        Script.from_string("1").to_string.should == "1"
+
+        Script.from_string("0 ffff OP_CODESEPARATOR 1 ffff 1 OP_CHECKMULTISIG").to_string.should == "0 ffff OP_CODESEPARATOR 1 ffff 1 OP_CHECKMULTISIG"
+
+        [1,2,4].all?{|n| script = "OP_PUSHDATA#{n} 01 ff"
+          Bitcoin::Script.binary_from_string(script) == Bitcoin::Script.binary_from_string( Bitcoin::Script.from_string(script).to_string )
+        }.should == true
+
+        #Script.from_string("-100").to_string.should == "OP_NOP"
+        #Script.from_string("100").to_string.should == "100"
+
+        proc{ Script.from_string("OP_NOP OP_UNKOWN") }.should.raise(Script::ScriptOpcodeError).message.should == "OP_UNKOWN not defined!"
       end
     end
 
-    it "should count sigops" do
-      [false, true].each do |accurate|
-        Script.from_string("OP_CHECKSIG").sigops_count_accurate(accurate).should == 1
-        Script.from_string("OP_CHECKSIGVERIFY").sigops_count_accurate(accurate).should == 1
-        Script.from_string("OP_CHECKSIG OP_CHECKSIGVERIFY").sigops_count_accurate(accurate).should == 2
-        Script.from_string("OP_CHECKSIG OP_CHECKSIG OP_CHECKSIG OP_CHECKSIG").sigops_count_accurate(accurate).should == 4
-        Script.from_string("1 OP_CHECKSIG 2 OP_CHECKSIG DEADBEEF OP_CHECKSIG 3 OP_CHECKSIG 4").sigops_count_accurate(accurate).should == 4
+    describe "get keys/addresses" do
+      it '#get_pubkey' do
+        Script.new(SCRIPT[0]).get_pubkey.should ==
+          "0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3"
+      end
+
+      it '#get_pubkey_address' do
+        Script.new(SCRIPT[0]).get_pubkey_address.should ==
+          "12cbQLTFMXRnSzktFkuoG3eHoMeFtpTu3S"
+      end
+
+      it "#get_hash160" do
+        Script.new(SCRIPT[2]).get_hash160.should ==
+          "17977bca1b6287a5e6559c57ef4b6525e9d7ded6"
+        Script.from_string("OP_DUP OP_HASH160 0 OP_EQUALVERIFY OP_CHECKSIG")
+          .get_hash160.should == nil
+      end
+
+      it "#get_hash160_address" do
+        Script.new(SCRIPT[2]).get_hash160_address.should ==
+          "139k1g5rtTsL4aGZbcASH3Fv3fUh9yBEdW"
+      end
+
+      it "#get_multisig_pubkeys" do
+        Script.new(SCRIPT[3]).get_multisig_pubkeys.should == [
+          "04573b6e9f3a714440048a7b87d606bcbf9e45b8586e70a67a3665ea720c095658471a523e5d923f3f3e015626e7c900bd08560ddffeb17d33c5b52c96edb87595",
+          "04039c2f4e413a26901e67ad4adbb6a4759af87bc16c7120459ecc9482fed3dd4a4502947f7b4c7782dcadc2bed513ed14d5e770452b97ae246ac2030f13b80a51",
+          "048b0f9d04e495c3c754f8c3c109196d713d0778882ef098f785570ee6043f8c192d8f84df43ebafbcc168f5d95a074dc4010b62c003e560abc163c312966b74b6"].map{|pk| [pk].pack("H*")}
+        Script.from_string("3 #{PUBKEYS[0..2].join(' ')} 3 OP_CHECKMULTISIG")
+          .get_multisig_pubkeys.should == [
+          "04fb0123fe2c399981bc77d522e2ae3268d2ab15e9a84ae49338a4b1db3886a1ea04cdab955d81e9fa1fcb0c062cb9a5af1ad5dd5064f4afcca322402b07030ec2",
+          "0423b8161514560bc8638054b6637ab78f400b24e5694ec8061db635d1f28a17902b14dbf4f80780da659ab24f11ded3095c780452a4004c30ab58dffac33d839a",
+          "04f43e76afac66bf3927638b6c4f7e324513ce56d2d658ac9d24c420d09993a4464eea6141a68a4748c092ad0e8f4ac29c4a2f661ef4d22b21f20110f42fcd6f6d"].map{|k|[k].pack("H*")}
+      end
+
+      it "#get_multisig_addresses" do
+        Script.new(SCRIPT[3]).get_multisig_addresses.should == [
+          "1JiaVc3N3U3CwwcLtzNX1Q4eYfeYxVjtuj", "19Fm2gY7qDTXriNTEhFY2wjxbHna3Gvenk",
+          "1B6k6g1d2L975i7beAbiBRxfBWhxomPxvy"]
+        Script.new(SCRIPT[4]).get_multisig_addresses.should == [
+          "1F2Nnyn7niMcheiYhkHrkc18aDxEkFowy5", "1EE7JGimkV7QqyHwXDJvk3b1yEN4ZUWeqx"]
+
+        # from tx 274f8be3b7b9b1a220285f5f71f61e2691dd04df9d69bb02a8b3b85f91fb1857, second pubkey has invalid encoding.
+        output = "1 0351efb6e91a31221652105d032a2508275f374cea63939ad72f1b1e02f477da78 00f2b7816db49d55d24df7bdffdbc1e203b424e8cd39f5651ab938e5e4a193569e 2 OP_CHECKMULTISIG"
+        Bitcoin::Script.from_string(output).get_multisig_addresses.should == ["1NdB761LmTmrJixxp93nz7pEiCx5cKPW44"]
+      end
+
+      it "#get_p2sh_address" do
+        Script.new(SCRIPT[5]).get_p2sh_address.should ==
+          "3FDuvkgzsW7LpzL9RBjtjvL7bFXCEeZ7xi"
+      end
+
+      it "#get_address" do
+        Script.new(SCRIPT[0]).get_address.should ==
+          "12cbQLTFMXRnSzktFkuoG3eHoMeFtpTu3S"
+        Script.new(SCRIPT[1]).get_address.should == nil
+        Script.new(SCRIPT[2]).get_address.should ==
+          "139k1g5rtTsL4aGZbcASH3Fv3fUh9yBEdW"
+        Script.new(SCRIPT[3]).get_address.should ==
+          "1JiaVc3N3U3CwwcLtzNX1Q4eYfeYxVjtuj"
+        Script.new(SCRIPT[4]).get_address.should ==
+          "1F2Nnyn7niMcheiYhkHrkc18aDxEkFowy5"
+        Script.new(SCRIPT[5]).get_address.should ==
+          "3FDuvkgzsW7LpzL9RBjtjvL7bFXCEeZ7xi"
+      end
+
+      it "#get_addresses" do
+        Script.new(SCRIPT[0]).get_addresses.
+          should == ["12cbQLTFMXRnSzktFkuoG3eHoMeFtpTu3S"]
+        Script.new(SCRIPT[3]).get_addresses
+          .should == ["1JiaVc3N3U3CwwcLtzNX1Q4eYfeYxVjtuj",
+          "19Fm2gY7qDTXriNTEhFY2wjxbHna3Gvenk", "1B6k6g1d2L975i7beAbiBRxfBWhxomPxvy"]
+      end
+
+      it "should get op_return data" do
+        Script.new(SCRIPT[6]).get_op_return_data.should == "deadbeef"
+        Script.new(SCRIPT[1]).get_op_return_data.should == nil
+        Script.from_string("OP_RETURN").get_op_return_data.should == nil
+        Script.from_string("OP_RETURN dead beef").get_op_return_data.should == nil
+        Script.from_string("OP_RETURN deadbeef").get_op_return_data.should == "deadbeef"
+        Script.from_string("OP_RETURN OP_CHECKSIG").get_op_return_data.should == "ac00"
+      end
+
+    end
+
+    describe "determine type" do
+
+      it '#is_standard?' do
+        Script.new(SCRIPT[0]).is_standard?.should == true
+        Script.new(SCRIPT[1]).is_standard?.should == false
+        Script.new(SCRIPT[2]).is_standard?.should == true
+        Script.new(SCRIPT[3]).is_standard?.should == true
+        Script.new(SCRIPT[4]).is_standard?.should == true
+        Script.new(SCRIPT[5]).is_standard?.should == true
+        Script.new(SCRIPT[6]).is_standard?.should == true
+      end
+
+      it '#is_pubkey?' do
+        Script.new(SCRIPT[0]).is_pubkey?.should == true
+        Script.new(SCRIPT[1]).is_pubkey?.should == false
+        Script.new(SCRIPT[2]).is_pubkey?.should == false
+        Script.new(SCRIPT[3]).is_pubkey?.should == false
+        Script.new(SCRIPT[4]).is_send_to_ip?.should == false
+        Script.new(SCRIPT[5]).is_pubkey?.should == false
+        Script.new(SCRIPT[6]).is_pubkey?.should == false
+        Script.from_string("0 OP_CHECKSIG").is_pubkey?.should == false # testnet aba0441c4c9933dcd7db789c39053739ec435ab742ed2c23c05f22f1488c0bfd
+      end
+
+      it "#is_hash160?" do
+        Script.new(SCRIPT[0]).is_hash160?.should == false
+        Script.new(SCRIPT[1]).is_pubkey?.should == false
+        Script.new(SCRIPT[2]).is_hash160?.should == true
+        Script.from_string("OP_DUP OP_HASH160 0 OP_EQUALVERIFY OP_CHECKSIG")
+          .is_hash160?.should == false
+        Script.new(SCRIPT[5]).is_hash160?.should == false
+        Script.new(SCRIPT[6]).is_hash160?.should == false
+      end
+
+      it "#is_multisig?" do
+        Script.new(SCRIPT[3]).is_multisig?.should == true
+        Script.new(SCRIPT[4]).is_multisig?.should == true
+        Script.new(SCRIPT[0]).is_multisig?.should == false
+        Script.new(SCRIPT[6]).is_multisig?.should == false
+        Script.new("OP_DUP OP_DROP 2 #{PUBKEYS[0..2].join(' ')} 3 OP_CHECKMULTISIG")
+          .is_multisig?.should == false
+        Script.new("OP_DROP OP_CHECKMULTISIG").is_multisig?.should == false
+        Script.from_string("d366fb5cbf048801b1bf0742bb0d873f65afb406f41756bd4a31865870f6a928 OP_DROP 2 02aae4b5cd593da83679a9c5cadad4c180c008a40dd3ed240cceb2933b9912da36 03a5aebd8b1b6eec06abc55fb13c72a9ed2143f9eed7d665970e38853d564bf1ab OP_CHECKMULTISIG").is_multisig?.should == false
+      end
+
+      it '#is_p2sh?' do
+        Script.new(SCRIPT[0]).is_p2sh?.should == false
+        Script.new(SCRIPT[1]).is_p2sh?.should == false
+        Script.new(SCRIPT[2]).is_p2sh?.should == false
+        Script.new(SCRIPT[3]).is_p2sh?.should == false
+        Script.new(SCRIPT[4]).is_p2sh?.should == false
+        Script.new(SCRIPT[5]).is_p2sh?.should == true
+        Script.new(SCRIPT[6]).is_p2sh?.should == false
+        Script.from_string("OP_DUP OP_HASH160 b689ebc262f50297139e7d16c4f8909e14ed4322 OP_EQUALVERIFY OP_CHECKSIGVERIFY OP_HASH160 1b6246121883816fc0637e4aa280aca1df219b1a OP_EQUAL")
+          .is_p2sh?.should == false
+      end
+
+      it '#is_op_return?' do
+        Script.new(SCRIPT[0]).is_op_return?.should == false
+        Script.new(SCRIPT[1]).is_op_return?.should == false
+        Script.new(SCRIPT[2]).is_op_return?.should == false
+        Script.new(SCRIPT[3]).is_op_return?.should == false
+        Script.new(SCRIPT[4]).is_op_return?.should == false
+        Script.new(SCRIPT[5]).is_op_return?.should == false
+        Script.new(SCRIPT[6]).is_op_return?.should == true
+        Script.from_string("OP_RETURN dead beef").is_op_return?.should == false
+        Script.from_string("OP_RETURN deadbeef").is_op_return?.should == true
+        Script.from_string("OP_RETURN OP_CHECKSIG").is_op_return?.should == true
+      end
+
+      it "#type" do
+        Script.new(SCRIPT[0]).type.should == :pubkey
+        Script.new(SCRIPT[1]).type.should == :unknown
+        Script.new(SCRIPT[2]).type.should == :hash160
+        Script.new(SCRIPT[3]).type.should == :multisig
+        Script.new(SCRIPT[4]).type.should == :multisig
+        Script.new(SCRIPT[5]).type.should == :p2sh
+        Script.new(SCRIPT[6]).type.should == :op_return
+        Script.from_string("OP_RETURN OP_CHECKSIG").type.should == :op_return
+        Script.from_string("OP_RETURN dead beef").type.should == :unknown
+      end
+
+    end
+
+    describe "generate scripts" do
+
+      it "should generate pubkey script" do
+        Script.to_pubkey_script(PUBKEYS[0]).should ==
+          Script.from_string("#{PUBKEYS[0]} OP_CHECKSIG").raw
+        Script.to_pubkey_script(PUBKEYS[1]).should ==
+          Script.from_string("#{PUBKEYS[1]} OP_CHECKSIG").raw
+      end
+
+      it "should generate hash160 script" do
+        Script.to_address_script('16Tc7znw2mfpWcqS84vBFfJ7PyoeHaXSz9')
+          .should == ["76a9143be0c2daaabbf3d53e47352c19d1e8f047e2f94188ac"].pack("H*")
+        hash160 = Bitcoin.hash160_from_address('16Tc7znw2mfpWcqS84vBFfJ7PyoeHaXSz9')
+        Script.to_hash160_script(hash160)
+          .should == Script.from_string("OP_DUP OP_HASH160 #{hash160} OP_EQUALVERIFY OP_CHECKSIG").raw
+        Script.to_address_script('mr1jU3Adw2pkvxTLvQA4MKpXB9Dynj9cXF')
+          .should == nil
+      end
+
+      it "should generate multisig script" do
+        Script.to_multisig_script(2, *PUBKEYS[0..2]).should ==
+          Script.from_string("2 #{PUBKEYS[0..2].join(' ')} 3 OP_CHECKMULTISIG").raw
+        Script.to_multisig_script(1, *PUBKEYS[0..1]).should ==
+          Script.from_string("1 #{PUBKEYS[0..1].join(' ')} 2 OP_CHECKMULTISIG").raw
+
+        m=n=16; Bitcoin::Script.new(Bitcoin::Script.to_multisig_script(m, *(["a"]*n))).to_string
+          .should == "16 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 16 OP_CHECKMULTISIG"
+        m=n=17; Bitcoin::Script.new(Bitcoin::Script.to_multisig_script(m, *(["a"]*n))).to_string
+          .should == "0:1:11 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 0:1:11 OP_CHECKMULTISIG"
+        m=n=20; Bitcoin::Script.new(Bitcoin::Script.to_multisig_script(m, *(["a"]*n))).to_string
+          .should == "0:1:14 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 a0 0:1:14 OP_CHECKMULTISIG"
+      end
+
+      it "should generate p2sh script" do
+        address = "3CkxTG25waxsmd13FFgRChPuGYba3ar36B"
+        hash160 = Bitcoin.hash160_from_address address
+        Script.to_p2sh_script(hash160).should ==
+          Script.from_string("OP_HASH160 #{hash160} OP_EQUAL").raw
+      end
+
+      it "should generate op_return script" do
+        Script.to_op_return_script("deadbeef").should == SCRIPT[6]
+        Script.to_op_return_script.should == Script.from_string("OP_RETURN").raw
+      end
+
+      it "should determine type for address script" do
+        address = '16Tc7znw2mfpWcqS84vBFfJ7PyoeHaXSz9'
+        hash160 = Bitcoin.hash160_from_address address
+        Script.to_address_script(address).should ==
+          Script.from_string("OP_DUP OP_HASH160 #{hash160} OP_EQUALVERIFY OP_CHECKSIG").raw
+
+        address = "3CkxTG25waxsmd13FFgRChPuGYba3ar36B"
+        hash160 = Bitcoin.hash160_from_address address
+        Script.to_p2sh_script(hash160).should ==
+          Script.from_string("OP_HASH160 #{hash160} OP_EQUAL").raw
+      end
+
+    end
+
+    describe "generate script sigs" do
+      before do
+        @sig = '3045022062437a8f60651cd968137355775fa8bdb83d4ca717fdbc08bf9868a051e0542f022100f5cd626c15ef0de0803ddf299e8895743e7ff484d6335874edfe086ee0a08fec'.htb
+      end
+
+      it "should generate pubkey script sig" do
+        pub = '04bc3e2b520d4be3e2651f2ba554392ea31edd69d2081186ab98acda3c4bf45e41a5f6e093277b774b5893347e38ffafce2b9e82226e6e0b378cf79b8c2eed983c'.htb
+        expected_script = '483045022062437a8f60651cd968137355775fa8bdb83d4ca717fdbc08bf9868a051e0542f022100f5cd626c15ef0de0803ddf299e8895743e7ff484d6335874edfe086ee0a08fec014104bc3e2b520d4be3e2651f2ba554392ea31edd69d2081186ab98acda3c4bf45e41a5f6e093277b774b5893347e38ffafce2b9e82226e6e0b378cf79b8c2eed983c'.htb
+
+        Script.to_pubkey_script_sig(@sig, pub).should == expected_script
+      end
+
+      it "should accept a compressed public key as input" do
+        pub = '02bc3e2b520d4be3e2651f2ba554392ea31edd69d2081186ab98acda3c4bf45e41'.htb
+        expected_script = '483045022062437a8f60651cd968137355775fa8bdb83d4ca717fdbc08bf9868a051e0542f022100f5cd626c15ef0de0803ddf299e8895743e7ff484d6335874edfe086ee0a08fec012102bc3e2b520d4be3e2651f2ba554392ea31edd69d2081186ab98acda3c4bf45e41'.htb
+
+        Script.to_pubkey_script_sig(@sig, pub).should == expected_script
+      end
+
+      it "should reject an improperly encoding public key" do
+        # Not binary encoded, like it's supposed to be.
+        pub = '02bc3e2b520d4be3e2651f2ba554392ea31edd69d2081186ab98acda3c4bf45e41'
+
+        lambda {
+          Script.to_pubkey_script_sig(@sig, pub)
+        }.should.raise
+      end
+
+      it "should support different hash types" do
+        hash_type = Script::SIGHASH_TYPE[:single]
+        pub = '04bc3e2b520d4be3e2651f2ba554392ea31edd69d2081186ab98acda3c4bf45e41a5f6e093277b774b5893347e38ffafce2b9e82226e6e0b378cf79b8c2eed983c'.htb
+        expected_script = '483045022062437a8f60651cd968137355775fa8bdb83d4ca717fdbc08bf9868a051e0542f022100f5cd626c15ef0de0803ddf299e8895743e7ff484d6335874edfe086ee0a08fec034104bc3e2b520d4be3e2651f2ba554392ea31edd69d2081186ab98acda3c4bf45e41a5f6e093277b774b5893347e38ffafce2b9e82226e6e0b378cf79b8c2eed983c'.htb
+
+        Script.to_pubkey_script_sig(@sig, pub, hash_type).should == expected_script
+      end
+
+      it "should generate multisig script sig" do
+        hash_type = Script::SIGHASH_TYPE[:none]
+        expected_script = '00483045022062437a8f60651cd968137355775fa8bdb83d4ca717fdbc08bf9868a051e0542f022100f5cd626c15ef0de0803ddf299e8895743e7ff484d6335874edfe086ee0a08fec02483045022062437a8f60651cd968137355775fa8bdb83d4ca717fdbc08bf9868a051e0542f022100f5cd626c15ef0de0803ddf299e8895743e7ff484d6335874edfe086ee0a08fec02'.htb
+
+        Script.to_multisig_script_sig(@sig, @sig, hash_type).should == expected_script
       end
     end
 
-    it "should count multisig as 20 sigops in legact inaccurate mode" do
-      Script.from_string("OP_CHECKMULTISIG").sigops_count_accurate(false).should == 20
-      Script.from_string("OP_CHECKMULTISIGVERIFY").sigops_count_accurate(false).should == 20
-      Script.from_string("OP_CHECKMULTISIG OP_CHECKMULTISIGVERIFY").sigops_count_accurate(false).should == 40
-      Script.from_string("1 OP_CHECKMULTISIG").sigops_count_accurate(false).should == 20
-      Script.from_string("5 OP_CHECKMULTISIG").sigops_count_accurate(false).should == 20
-      Script.from_string("40 OP_CHECKMULTISIG").sigops_count_accurate(false).should == 20
+
+    describe "signatures_count" do
+
+      it "should be zero in data-only scripts" do
+        [false, true].each do |accurate|
+          Script.from_string("").sigops_count_accurate(accurate).should == 0
+          Script.from_string("DEADBEEF").sigops_count_accurate(accurate).should == 0
+          Script.from_string("DEAD BEEF").sigops_count_accurate(accurate).should == 0
+          Script.from_string("DE AD BE EF").sigops_count_accurate(accurate).should == 0
+          Script.from_string("OP_NOP").sigops_count_accurate(accurate).should == 0
+          Script.from_string("0").sigops_count_accurate(accurate).should == 0
+          Script.from_string("0 1").sigops_count_accurate(accurate).should == 0
+          Script.from_string("0 1 2 3").sigops_count_accurate(accurate).should == 0
+        end
+      end
+
+      it "should count sigops" do
+        [false, true].each do |accurate|
+          Script.from_string("OP_CHECKSIG").sigops_count_accurate(accurate).should == 1
+          Script.from_string("OP_CHECKSIGVERIFY").sigops_count_accurate(accurate).should == 1
+          Script.from_string("OP_CHECKSIG OP_CHECKSIGVERIFY").sigops_count_accurate(accurate).should == 2
+          Script.from_string("OP_CHECKSIG OP_CHECKSIG OP_CHECKSIG OP_CHECKSIG").sigops_count_accurate(accurate).should == 4
+          Script.from_string("1 OP_CHECKSIG 2 OP_CHECKSIG DEADBEEF OP_CHECKSIG 3 OP_CHECKSIG 4").sigops_count_accurate(accurate).should == 4
+        end
+      end
+
+      it "should count multisig as 20 sigops in legact inaccurate mode" do
+        Script.from_string("OP_CHECKMULTISIG").sigops_count_accurate(false).should == 20
+        Script.from_string("OP_CHECKMULTISIGVERIFY").sigops_count_accurate(false).should == 20
+        Script.from_string("OP_CHECKMULTISIG OP_CHECKMULTISIGVERIFY").sigops_count_accurate(false).should == 40
+        Script.from_string("1 OP_CHECKMULTISIG").sigops_count_accurate(false).should == 20
+        Script.from_string("5 OP_CHECKMULTISIG").sigops_count_accurate(false).should == 20
+        Script.from_string("40 OP_CHECKMULTISIG").sigops_count_accurate(false).should == 20
+      end
+
+      it "should count multisig accurately using number of pubkeys" do
+        Script.from_string("1 OP_CHECKMULTISIG").sigops_count_accurate(true).should == 1
+        Script.from_string("1 OP_CHECKMULTISIGVERIFY").sigops_count_accurate(true).should == 1
+        Script.from_string("2 OP_CHECKMULTISIG").sigops_count_accurate(true).should == 2
+        Script.from_string("2 OP_CHECKMULTISIGVERIFY").sigops_count_accurate(true).should == 2
+        Script.from_string("15 OP_CHECKMULTISIG").sigops_count_accurate(true).should == 15
+        Script.from_string("15 OP_CHECKMULTISIGVERIFY").sigops_count_accurate(true).should == 15
+        Script.from_string("16 OP_CHECKMULTISIG").sigops_count_accurate(true).should == 16
+        Script.from_string("16 OP_CHECKMULTISIGVERIFY").sigops_count_accurate(true).should == 16
+        Script.from_string("4 OP_CHECKMULTISIG 7 OP_CHECKMULTISIGVERIFY").sigops_count_accurate(true).should == 11
+      end
+
+      it "should count multisig as 20 sigops in accurate mode when the pubkey count is missing" do
+        Script.from_string("OP_CHECKMULTISIG").sigops_count_accurate(true).should == 20
+        Script.from_string("OP_CHECKMULTISIGVERIFY").sigops_count_accurate(true).should == 20
+      end
+
+      it "should count multisig as 20 sigops when pubkey count is not OP_{1,...,16}, but bignum as pushdata" do
+        Script.from_string("#{Script::OP_PUSHDATA1}:1:01 OP_CHECKMULTISIG").sigops_count_accurate(true).should == 20
+        Script.from_string("#{Script::OP_PUSHDATA1}:1:02 OP_CHECKMULTISIGVERIFY").sigops_count_accurate(true).should == 20
+      end
+
+      it "should count multisig as 20 sigops in accurate mode when the pubkey count is out of bounds" do
+        Script.from_string("0 OP_CHECKMULTISIG").sigops_count_accurate(true).should == 20
+        Script.from_string("0 OP_CHECKMULTISIGVERIFY").sigops_count_accurate(true).should == 20
+        Script.from_string("0 OP_CHECKMULTISIG 0 OP_CHECKMULTISIGVERIFY").sigops_count_accurate(true).should == 40
+        Script.from_string("DEADBEEF OP_CHECKMULTISIG").sigops_count_accurate(true).should == 20
+        Script.from_string("#{Script::OP_PUSHDATA1}:1:11 OP_CHECKMULTISIG").sigops_count_accurate(true).should == 20
+      end
+
+      it "should extract signature count from P2SH scriptSig" do
+
+        # Given a P2SH input script (the one with the signatures and a serialized script inside)
+        # This should count as 12 sigops (1 + 4 + 7)
+        script = Script.from_string("OP_CHECKSIG 4 OP_CHECKMULTISIG 7 OP_CHECKMULTISIGVERIFY")
+
+        # Serialize the script to be used as a plain pushdata (which will be decoded as a script).
+        serialized_script = Script.new("").append_pushdata(script.to_binary)
+
+        # If empty should return 0.
+        Script.from_string("").sigops_count_for_p2sh.should == 0
+
+        # If ends with OP_N
+        Script.from_string("0").sigops_count_for_p2sh.should == 0
+        Script.from_string("1").sigops_count_for_p2sh.should == 0
+        Script.from_string("5").sigops_count_for_p2sh.should == 0
+        Script.from_string("16").sigops_count_for_p2sh.should == 0
+
+        # If ends with opcode
+        Script.from_string("OP_NOP").sigops_count_for_p2sh.should == 0
+        Script.from_string("OP_HASH160").sigops_count_for_p2sh.should == 0
+        Script.from_string("OP_CHECKSIG").sigops_count_for_p2sh.should == 0
+        Script.from_string("DEADBEEF OP_NOP").sigops_count_for_p2sh.should == 0
+        Script.from_string("DEADBEEF OP_HASH160").sigops_count_for_p2sh.should == 0
+        Script.from_string("DEADBEEF OP_CHECKSIG").sigops_count_for_p2sh.should == 0
+
+        # If only has the script, should parse it well
+        serialized_script.sigops_count_for_p2sh.should == 12
+
+        # If ends with the script, should also parse well.
+        Script.new(Script.from_string("DEADBEEF CAFEBABE").to_binary + serialized_script.to_binary).sigops_count_for_p2sh.should == 12
+        Script.new(Script.from_string("DEADBEEF 1").to_binary + serialized_script.to_binary).sigops_count_for_p2sh.should == 12
+
+        # If has the script, but ends with non-script, should return 0
+        # DEADBEEF is a script with OP_CHECKSIGVERIFY in it, so we wrap it in a serialized script with plain pushdata to have 0 count.
+        Script.new(serialized_script.to_binary + Script.new("").append_pushdata(Script.from_string("DEADBEEF").to_binary).to_binary).sigops_count_for_p2sh.should == 0
+        Script.new(serialized_script.to_binary + Script.from_string("1").to_binary).sigops_count_for_p2sh.should == 0
+      end
+
+      it "should count sigops up until an invalid OP_PUSHDATA" do
+        script_binary = Bitcoin::Protocol.read_binary_file(fixtures_path("txscript-invalid-too-many-sigops-followed-by-invalid-pushdata.bin"))
+        Script.new(script_binary).sigops_count_accurate(false).should == 39998
+      end
+
     end
 
-    it "should count multisig accurately using number of pubkeys" do
-      Script.from_string("1 OP_CHECKMULTISIG").sigops_count_accurate(true).should == 1
-      Script.from_string("1 OP_CHECKMULTISIGVERIFY").sigops_count_accurate(true).should == 1
-      Script.from_string("2 OP_CHECKMULTISIG").sigops_count_accurate(true).should == 2
-      Script.from_string("2 OP_CHECKMULTISIGVERIFY").sigops_count_accurate(true).should == 2
-      Script.from_string("15 OP_CHECKMULTISIG").sigops_count_accurate(true).should == 15
-      Script.from_string("15 OP_CHECKMULTISIGVERIFY").sigops_count_accurate(true).should == 15
-      Script.from_string("16 OP_CHECKMULTISIG").sigops_count_accurate(true).should == 16
-      Script.from_string("16 OP_CHECKMULTISIGVERIFY").sigops_count_accurate(true).should == 16
-      Script.from_string("4 OP_CHECKMULTISIG 7 OP_CHECKMULTISIGVERIFY").sigops_count_accurate(true).should == 11
+    it '#run' do
+      script = SCRIPT[1] + SCRIPT[0]
+      Script.new(script).run.should == true
+
+      Script.from_string("1 OP_DUP OP_DROP 1 OP_EQUAL")
+        .run.should == true
+      Script.from_string("1 OP_DUP OP_DROP 1 OP_EQUAL")
+        .run.should == true
+      Script.from_string("foo OP_DUP OP_DROP foo OP_EQUAL")
+        .run.should == true
+      Script.from_string("bar foo OP_DUP OP_DROP bar OP_EQUAL")
+        .run.should == false
+
+      Script.from_string("1 OP_DROP 2").run.should == true
+
+      # testnet3 tx: 5dea81f9d9d2ea6d06ce23ff225d1e240392519017643f75c96fa2e4316d948a
+      script = Script.new( ["0063bac0d0e0f0f1f2f3f3f4ff675168"].pack("H*") )
+      script.to_string.should == "0 OP_IF (opcode-186) (opcode-192) (opcode-208) (opcode-224) (opcode-240) (opcode-241) (opcode-242) (opcode-243) (opcode-243) (opcode-244) OP_INVALIDOPCODE OP_ELSE 1 OP_ENDIF"
+      script.run.should == true
+
+      # mainnet tx: 61a078472543e9de9247446076320499c108b52307d8d0fafbe53b5c4e32acc4 redeeming output from 5342c96b946ea2c5e497de5dbf7762021f94aba2c8222c17ed28492fdbb4a6d9
+      script = Bitcoin::Script.from_string("16cfb9bc7654ef1d7723e5c2722fc0c3d505045e OP_SIZE OP_DUP 1 OP_GREATERTHAN OP_VERIFY OP_NEGATE OP_HASH256 OP_HASH160 OP_SHA256 OP_SHA1 OP_RIPEMD160 OP_EQUAL")
+      script.run.should == true
+
+      # mainnet tx: 340aa9f72206d600b7e89c9137e4d2d77a920723f83e34707ff452121fd48492 redeeming output from f2d72a7bf22e29e3f2dc721afbf0a922860f81db9fc7eb397937f9d7e87cc438
+      script = Bitcoin::Script.from_string("027ce87f6f41dd4d7d874b40889f7df6b288f77f OP_DEPTH OP_HASH256 OP_HASH160 OP_SHA256 OP_SHA1 OP_RIPEMD160 OP_EQUAL")
+      script.run.should == true
     end
 
-    it "should count multisig as 20 sigops in accurate mode when the pubkey count is missing" do
-      Script.from_string("OP_CHECKMULTISIG").sigops_count_accurate(true).should == 20
-      Script.from_string("OP_CHECKMULTISIGVERIFY").sigops_count_accurate(true).should == 20
+    it "should run op_checkmultisig p2sh script with empty signature" do
+      # mainnet tx: b78706427923f73b334fd68040f35900503da33c671723c41ca845f6fba6c29c
+      tx1 = Bitcoin::P::Tx.new("01000000023904cd3644c6d440a6d752c95f07737c46f5e70fb6fbb28f00aa17e281868b7b010000006b483045022100ac455750dc430957942e9766f88aecfe6eb17d4244eb2cb50ca4a25336fd4dd702202640cc943f4fe8f2166b03005bed3bd024f4762767322b60bf471ecf8e3f3ede012102348d4cad0084f88c4c02bdc1bf90cc6c0893a0b97af76ef644daf72e6786b4afffffffffb84057ae61ad22ac17c02635ee1b37d170ef785847ec28efe848a5607331568e020000006b483045022100d7fee595d7a1f9969767098f8582e7a563f08437f461f0a25395f35c1833839302205f565ab12d343478471a78669c4c3476714032f7758a781d7deab19f160784e0012102ea69c47753d8e0228c0c426294a6b4dc926aebbeb8561248d40be37d257d94e0ffffffff01a08601000000000017a91438430c4d1c214bf11d2c0c3dea8e5e9a5d11aab08700000000".htb)
+      # mainnet tx: 136becd0892fa38c5aca8104db8b90b3a0e6b40912b7d1462aed583c067054cd
+      tx2 = Bitcoin::P::Tx.new("01000000019cc2a6fbf645a81cc42317673ca33d500059f34080d64f333bf72379420687b70000000008000051005102ae91ffffffff0150c300000000000002ae9100000000".htb)
+      tx2.verify_input_signature(0, tx1).should == true
     end
 
-    it "should count multisig as 20 sigops when pubkey count is not OP_{1,...,16}, but bignum as pushdata" do
-      Script.from_string("#{Script::OP_PUSHDATA1}:1:01 OP_CHECKMULTISIG").sigops_count_accurate(true).should == 20
-      Script.from_string("#{Script::OP_PUSHDATA1}:1:02 OP_CHECKMULTISIGVERIFY").sigops_count_accurate(true).should == 20
+    it "should debug script branches (OP_IF/NOTIF/ELSE/ENDIF) correctly" do
+
+      script = Bitcoin::Script.from_string("1 OP_NOTIF OP_RETURN OP_ENDIF")
+      script.run {}
+      script.debug.should == [
+        [], "OP_1",
+        [1], "OP_NOTIF",
+        [], "OP_ENDIF",
+        [], "RESULT"
+      ]
+
+      script = Bitcoin::Script.from_string("1 OP_IF OP_RETURN OP_ENDIF")
+      script.run {}
+      script.debug.should == [
+        [], "OP_1",
+        [1], "OP_IF",
+        [], "OP_RETURN",
+        [], "INVALID TRANSACTION", "RESULT"
+      ]
+
+      script = Bitcoin::Script.from_string("1 OP_IF OP_2 OP_ELSE OP_3 OP_ENDIF OP_2 OP_EQUAL")
+      script.run {}
+      script.debug.should == [
+        [], "OP_1",
+        [1], "OP_IF",
+        [], "OP_2",
+        [2], "OP_ELSE",
+        [2], "OP_ENDIF",
+        [2], "OP_2",
+        [2, 2], "OP_EQUAL",
+        [1], "RESULT"]
+
+      script = Bitcoin::Script.from_string("0 OP_IF OP_2 OP_ELSE OP_3 OP_ENDIF OP_2 OP_EQUAL")
+      script.run {}
+      script.debug.should == [
+        [], "OP_0",
+        [[""]], "OP_IF",
+        [], "OP_ELSE",
+        [], "OP_3",
+        [3], "OP_ENDIF",
+        [3], "OP_2",
+        [3, 2], "OP_EQUAL",
+        [0], "RESULT"]
+
+      script = Bitcoin::Script.from_string("0 OP_IF deadbeef OP_ELSE OP_3 OP_ENDIF OP_2 OP_EQUAL")
+      script.run {}
+      script.debug.should == [
+        [], "OP_0",
+        [[""]], "OP_IF",
+        [], "OP_ELSE",
+        [], "OP_3",
+        [3], "OP_ENDIF",
+        [3], "OP_2",
+        [3, 2], "OP_EQUAL",
+        [0], "RESULT"]
+
+      script = Bitcoin::Script.from_string("1 OP_IF 2 OP_ELSE 3 OP_ENDIF 2 OP_EQUAL")
+      script.run {}
+      script.debug.should ==  [[], "OP_1", [1], "OP_IF", [], "OP_2", [2], "OP_ELSE", [2], "OP_ENDIF", [2], "OP_2", [2, 2], "OP_EQUAL", [1], "RESULT"]
+
+      script = Bitcoin::Script.from_string("
+  0
+  3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501
+  304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301
+  1
+  635221022d73c0041da9794fcaa7286fcce35e126f84f8b53563be6abb3b213f964bfbfc2102ab2445a289939e49e326dd29ca068cb38d1c9ef7618b7272d14c79c1abdea5cd52ae675221025182b1ca9a1ea9358f61cb363ac80c80b145204d9c4d875c35873d3d578853
+  OP_IF
+  2
+  022d73c0041da9794fcaa7286fcce35e126f84f8b53563be6abb3b213f964bfbfc
+  02ab2445a289939e49e326dd29ca068cb38d1c9ef7618b7272d14c79c1abdea5cd
+  2
+  OP_CHECKMULTISIG
+  OP_ELSE
+  2
+  025182b1ca9a1ea9358f61cb363ac80c80b145204d9c4d875c35873d3d57885348
+  02b18808b3e6857e396167890a52f898cbd5215354f027b89fed895058e49a158b
+  2
+  OP_CHECKMULTISIG
+  OP_ENDIF")
+      script.run {}
+      script.debug.should == [
+        [], "OP_0",
+        [[""]], "PUSH DATA 3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501",
+        [[""], ["3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501"]], "PUSH DATA 304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301",
+        [[""], ["3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501"], ["304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301"]], "OP_1",
+        [[""], ["3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501"], ["304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301"], 1], "PUSH DATA 635221022d73c0041da9794fcaa7286fcce35e126f84f8b53563be6abb3b213f964bfbfc2102ab2445a289939e49e326dd29ca068cb38d1c9ef7618b7272d14c79c1abdea5cd52ae675221025182b1ca9a1ea9358f61cb363ac80c80b145204d9c4d875c35873d3d578853",
+        [[""], ["3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501"], ["304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301"], 1, ["635221022d73c0041da9794fcaa7286fcce35e126f84f8b53563be6abb3b213f964bfbfc2102ab2445a289939e49e326dd29ca068cb38d1c9ef7618b7272d14c79c1abdea5cd52ae675221025182b1ca9a1ea9358f61cb363ac80c80b145204d9c4d875c35873d3d578853"]], "OP_IF",
+
+        [[""], ["3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501"], ["304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301"], 1], "OP_2",
+        [[""], ["3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501"], ["304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301"], 1, 2], "PUSH DATA 022d73c0041da9794fcaa7286fcce35e126f84f8b53563be6abb3b213f964bfbfc",
+        [[""], ["3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501"], ["304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301"], 1, 2, ["022d73c0041da9794fcaa7286fcce35e126f84f8b53563be6abb3b213f964bfbfc"]], "PUSH DATA 02ab2445a289939e49e326dd29ca068cb38d1c9ef7618b7272d14c79c1abdea5cd",
+        [[""], ["3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501"], ["304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301"], 1, 2, ["022d73c0041da9794fcaa7286fcce35e126f84f8b53563be6abb3b213f964bfbfc"], ["02ab2445a289939e49e326dd29ca068cb38d1c9ef7618b7272d14c79c1abdea5cd"]], "OP_2",
+        [[""], ["3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501"], ["304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301"], 1, 2, ["022d73c0041da9794fcaa7286fcce35e126f84f8b53563be6abb3b213f964bfbfc"], ["02ab2445a289939e49e326dd29ca068cb38d1c9ef7618b7272d14c79c1abdea5cd"], 2], "OP_CHECKMULTISIG",
+        [[""], 0], "OP_ELSE",
+        [[""], 0], "OP_ENDIF",
+        [[""], 0], "RESULT"]
     end
 
-    it "should count multisig as 20 sigops in accurate mode when the pubkey count is out of bounds" do
-      Script.from_string("0 OP_CHECKMULTISIG").sigops_count_accurate(true).should == 20
-      Script.from_string("0 OP_CHECKMULTISIGVERIFY").sigops_count_accurate(true).should == 20
-      Script.from_string("0 OP_CHECKMULTISIG 0 OP_CHECKMULTISIGVERIFY").sigops_count_accurate(true).should == 40
-      Script.from_string("DEADBEEF OP_CHECKMULTISIG").sigops_count_accurate(true).should == 20
-      Script.from_string("#{Script::OP_PUSHDATA1}:1:11 OP_CHECKMULTISIG").sigops_count_accurate(true).should == 20
+    it "should not execute p2sh recursively" do
+      # this script_sig includes a pattern that matches the p2sh template
+      script_sig = "0 a914b472a266d0bd89c13706a4132ccfb16f7c3b9fcb87"
+      pk_script = "OP_HASH160 92a04bc86e23f169691bd6926d11853cc61e1852 OP_EQUAL"
+      script = Bitcoin::Script.from_string(script_sig + " " + pk_script)
+      script.run.should == true
     end
 
-    it "should extract signature count from P2SH scriptSig" do
+    def build_p2sh_multisig_tx(m, *keys)
+      redeem_script = Bitcoin::Script.to_multisig_script(m, *keys.map(&:pub))
+      p2sh_address = Bitcoin.hash160_to_p2sh_address(Bitcoin.hash160(redeem_script.hth))
 
-      # Given a P2SH input script (the one with the signatures and a serialized script inside)
-      # This should count as 12 sigops (1 + 4 + 7)
-      script = Script.from_string("OP_CHECKSIG 4 OP_CHECKMULTISIG 7 OP_CHECKMULTISIGVERIFY")
+      prev_tx = build_tx {|t| t.input {|i| i.coinbase}
+        t.output {|o| o.to p2sh_address; o.value 50e8 } }
+      tx = build_tx {|t| t.input {|i| i.prev_out prev_tx, 0 }
+        t.output {|o| o.to Bitcoin::Key.generate.addr; o.value 50e8 } }
 
-      # Serialize the script to be used as a plain pushdata (which will be decoded as a script).
-      serialized_script = Script.new("").append_pushdata(script.to_binary)
-
-      # If empty should return 0.
-      Script.from_string("").sigops_count_for_p2sh.should == 0
-
-      # If ends with OP_N
-      Script.from_string("0").sigops_count_for_p2sh.should == 0
-      Script.from_string("1").sigops_count_for_p2sh.should == 0
-      Script.from_string("5").sigops_count_for_p2sh.should == 0
-      Script.from_string("16").sigops_count_for_p2sh.should == 0
-
-      # If ends with opcode
-      Script.from_string("OP_NOP").sigops_count_for_p2sh.should == 0
-      Script.from_string("OP_HASH160").sigops_count_for_p2sh.should == 0
-      Script.from_string("OP_CHECKSIG").sigops_count_for_p2sh.should == 0
-      Script.from_string("DEADBEEF OP_NOP").sigops_count_for_p2sh.should == 0
-      Script.from_string("DEADBEEF OP_HASH160").sigops_count_for_p2sh.should == 0
-      Script.from_string("DEADBEEF OP_CHECKSIG").sigops_count_for_p2sh.should == 0
-
-      # If only has the script, should parse it well
-      serialized_script.sigops_count_for_p2sh.should == 12
-
-      # If ends with the script, should also parse well.
-      Script.new(Script.from_string("DEADBEEF CAFEBABE").to_binary + serialized_script.to_binary).sigops_count_for_p2sh.should == 12
-      Script.new(Script.from_string("DEADBEEF 1").to_binary + serialized_script.to_binary).sigops_count_for_p2sh.should == 12
-
-      # If has the script, but ends with non-script, should return 0
-      # DEADBEEF is a script with OP_CHECKSIGVERIFY in it, so we wrap it in a serialized script with plain pushdata to have 0 count.
-      Script.new(serialized_script.to_binary + Script.new("").append_pushdata(Script.from_string("DEADBEEF").to_binary).to_binary).sigops_count_for_p2sh.should == 0
-      Script.new(serialized_script.to_binary + Script.from_string("1").to_binary).sigops_count_for_p2sh.should == 0
+      sig_hash = tx.signature_hash_for_input(0, redeem_script)
+      return prev_tx, tx, redeem_script, sig_hash
     end
 
-    it "should count sigops up until an invalid OP_PUSHDATA" do
-      script_binary = Bitcoin::Protocol.read_binary_file(fixtures_path("txscript-invalid-too-many-sigops-followed-by-invalid-pushdata.bin"))
-      Script.new(script_binary).sigops_count_accurate(false).should == 39998
+    it "#sort_p2sh_multisig_signatures 3-of-3" do
+      keys = 3.times.map { Bitcoin::Key.generate }
+
+      prev_tx, tx, redeem_script, sig_hash = build_p2sh_multisig_tx(3, *keys)
+      sigs = keys.map {|k| k.sign(sig_hash) }
+
+      # add sigs in all possible orders, sort them, and see if they are valid
+      [0, 1, 2].permutation do |order|
+        script_sig = Script.to_p2sh_multisig_script_sig(redeem_script)
+        order.each{|i| script_sig = Script.add_sig_to_multisig_script_sig(sigs[i], script_sig)}
+        script_sig = Script.sort_p2sh_multisig_signatures(script_sig, sig_hash)
+        tx.in[0].script_sig = script_sig
+        tx.verify_input_signature(0, prev_tx).should == true
+      end
+    end
+
+    it "#sort_p2sh_multisig_signatures 2-of-3" do
+      keys = 3.times.map { Bitcoin::Key.generate }
+
+      prev_tx, tx, redeem_script, sig_hash = build_p2sh_multisig_tx(2, *keys)
+      sigs = keys.map {|k| k.sign(sig_hash) }
+
+      # add sigs in all possible orders, sort them, and see if they are valid
+      [0, 1, 2].permutation(2) do |order|
+        script_sig = Script.to_p2sh_multisig_script_sig(redeem_script)
+        order.each{|i| script_sig = Script.add_sig_to_multisig_script_sig(sigs[i], script_sig)}
+        script_sig = Script.sort_p2sh_multisig_signatures(script_sig, sig_hash)
+        tx.in[0].script_sig = script_sig
+        tx.verify_input_signature(0, prev_tx).should == true
+      end
     end
 
   end
 
-  it '#run' do
-    script = SCRIPT[1] + SCRIPT[0]
-    Script.new(script).run.should == true
+  describe "Implements BIP62" do
+    it 'tests for incorrectly encoded S-values in signatures' do
+      # TX 3da75972766f0ad13319b0b461fd16823a731e44f6e9de4eb3c52d6a6fb6c8ae
+      sig_orig = ["304502210088984573e3e4f33db7df6aea313f1ce67a3ef3532ea89991494c7f018258371802206ceefc9291450dbd40d834f249658e0f64662d52a41cf14e20c9781144f2fe0701"].pack("H*")
+      Bitcoin::Script::is_low_der_signature?(sig_orig).should == true
 
-    Script.from_string("1 OP_DUP OP_DROP 1 OP_EQUAL")
-      .run.should == true
-    Script.from_string("1 OP_DUP OP_DROP 1 OP_EQUAL")
-      .run.should == true
-    Script.from_string("foo OP_DUP OP_DROP foo OP_EQUAL")
-      .run.should == true
-    Script.from_string("bar foo OP_DUP OP_DROP bar OP_EQUAL")
-      .run.should == false
+      # Set the start of the S-value to 0xff so it's well above the order of the curve divided by two
+      sig = sig_orig.unpack("C*")
+      length_r = sig[3]
+      sig[6 + length_r] = 0xff
 
-    Script.from_string("1 OP_DROP 2").run.should == true
-
-    # testnet3 tx: 5dea81f9d9d2ea6d06ce23ff225d1e240392519017643f75c96fa2e4316d948a
-    script = Script.new( ["0063bac0d0e0f0f1f2f3f3f4ff675168"].pack("H*") )
-    script.to_string.should == "0 OP_IF (opcode-186) (opcode-192) (opcode-208) (opcode-224) (opcode-240) (opcode-241) (opcode-242) (opcode-243) (opcode-243) (opcode-244) OP_INVALIDOPCODE OP_ELSE 1 OP_ENDIF"
-    script.run.should == true
-
-    # mainnet tx: 61a078472543e9de9247446076320499c108b52307d8d0fafbe53b5c4e32acc4 redeeming output from 5342c96b946ea2c5e497de5dbf7762021f94aba2c8222c17ed28492fdbb4a6d9
-    script = Bitcoin::Script.from_string("16cfb9bc7654ef1d7723e5c2722fc0c3d505045e OP_SIZE OP_DUP 1 OP_GREATERTHAN OP_VERIFY OP_NEGATE OP_HASH256 OP_HASH160 OP_SHA256 OP_SHA1 OP_RIPEMD160 OP_EQUAL")
-    script.run.should == true
-
-    # mainnet tx: 340aa9f72206d600b7e89c9137e4d2d77a920723f83e34707ff452121fd48492 redeeming output from f2d72a7bf22e29e3f2dc721afbf0a922860f81db9fc7eb397937f9d7e87cc438
-    script = Bitcoin::Script.from_string("027ce87f6f41dd4d7d874b40889f7df6b288f77f OP_DEPTH OP_HASH256 OP_HASH160 OP_SHA256 OP_SHA1 OP_RIPEMD160 OP_EQUAL")
-    script.run.should == true
-  end
-
-  it "should run op_checkmultisig p2sh script with empty signature" do
-    # mainnet tx: b78706427923f73b334fd68040f35900503da33c671723c41ca845f6fba6c29c
-    tx1 = Bitcoin::P::Tx.new("01000000023904cd3644c6d440a6d752c95f07737c46f5e70fb6fbb28f00aa17e281868b7b010000006b483045022100ac455750dc430957942e9766f88aecfe6eb17d4244eb2cb50ca4a25336fd4dd702202640cc943f4fe8f2166b03005bed3bd024f4762767322b60bf471ecf8e3f3ede012102348d4cad0084f88c4c02bdc1bf90cc6c0893a0b97af76ef644daf72e6786b4afffffffffb84057ae61ad22ac17c02635ee1b37d170ef785847ec28efe848a5607331568e020000006b483045022100d7fee595d7a1f9969767098f8582e7a563f08437f461f0a25395f35c1833839302205f565ab12d343478471a78669c4c3476714032f7758a781d7deab19f160784e0012102ea69c47753d8e0228c0c426294a6b4dc926aebbeb8561248d40be37d257d94e0ffffffff01a08601000000000017a91438430c4d1c214bf11d2c0c3dea8e5e9a5d11aab08700000000".htb)
-    # mainnet tx: 136becd0892fa38c5aca8104db8b90b3a0e6b40912b7d1462aed583c067054cd
-    tx2 = Bitcoin::P::Tx.new("01000000019cc2a6fbf645a81cc42317673ca33d500059f34080d64f333bf72379420687b70000000008000051005102ae91ffffffff0150c300000000000002ae9100000000".htb)
-    tx2.verify_input_signature(0, tx1).should == true
-  end
-
-  it "should debug script branches (OP_IF/NOTIF/ELSE/ENDIF) correctly" do
-
-    script = Bitcoin::Script.from_string("1 OP_NOTIF OP_RETURN OP_ENDIF")
-    script.run {}
-    script.debug.should == [
-      [], "OP_1",
-      [1], "OP_NOTIF",
-      [], "OP_ENDIF",
-      [], "RESULT"
-    ]
-
-    script = Bitcoin::Script.from_string("1 OP_IF OP_RETURN OP_ENDIF")
-    script.run {}
-    script.debug.should == [
-      [], "OP_1",
-      [1], "OP_IF",
-      [], "OP_RETURN",
-      [], "INVALID TRANSACTION", "RESULT"
-    ]
-
-    script = Bitcoin::Script.from_string("1 OP_IF OP_2 OP_ELSE OP_3 OP_ENDIF OP_2 OP_EQUAL")
-    script.run {}
-    script.debug.should == [
-      [], "OP_1",
-      [1], "OP_IF",
-      [], "OP_2",
-      [2], "OP_ELSE",
-      [2], "OP_ENDIF",
-      [2], "OP_2",
-      [2, 2], "OP_EQUAL",
-      [1], "RESULT"]
-
-    script = Bitcoin::Script.from_string("0 OP_IF OP_2 OP_ELSE OP_3 OP_ENDIF OP_2 OP_EQUAL")
-    script.run {}
-    script.debug.should == [
-      [], "OP_0",
-      [[""]], "OP_IF",
-      [], "OP_ELSE",
-      [], "OP_3",
-      [3], "OP_ENDIF",
-      [3], "OP_2",
-      [3, 2], "OP_EQUAL",
-      [0], "RESULT"]
-
-    script = Bitcoin::Script.from_string("0 OP_IF deadbeef OP_ELSE OP_3 OP_ENDIF OP_2 OP_EQUAL")
-    script.run {}
-    script.debug.should == [
-      [], "OP_0",
-      [[""]], "OP_IF",
-      [], "OP_ELSE",
-      [], "OP_3",
-      [3], "OP_ENDIF",
-      [3], "OP_2",
-      [3, 2], "OP_EQUAL",
-      [0], "RESULT"]
-
-    script = Bitcoin::Script.from_string("1 OP_IF 2 OP_ELSE 3 OP_ENDIF 2 OP_EQUAL")
-    script.run {}
-    script.debug.should ==  [[], "OP_1", [1], "OP_IF", [], "OP_2", [2], "OP_ELSE", [2], "OP_ENDIF", [2], "OP_2", [2, 2], "OP_EQUAL", [1], "RESULT"]
-
-    script = Bitcoin::Script.from_string("
-0
-3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501
-304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301
-1
-635221022d73c0041da9794fcaa7286fcce35e126f84f8b53563be6abb3b213f964bfbfc2102ab2445a289939e49e326dd29ca068cb38d1c9ef7618b7272d14c79c1abdea5cd52ae675221025182b1ca9a1ea9358f61cb363ac80c80b145204d9c4d875c35873d3d578853
-OP_IF
-2
-022d73c0041da9794fcaa7286fcce35e126f84f8b53563be6abb3b213f964bfbfc
-02ab2445a289939e49e326dd29ca068cb38d1c9ef7618b7272d14c79c1abdea5cd
-2
-OP_CHECKMULTISIG
-OP_ELSE
-2
-025182b1ca9a1ea9358f61cb363ac80c80b145204d9c4d875c35873d3d57885348
-02b18808b3e6857e396167890a52f898cbd5215354f027b89fed895058e49a158b
-2
-OP_CHECKMULTISIG
-OP_ENDIF")
-    script.run {}
-    script.debug.should == [
-      [], "OP_0",
-      [[""]], "PUSH DATA 3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501",
-      [[""], ["3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501"]], "PUSH DATA 304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301",
-      [[""], ["3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501"], ["304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301"]], "OP_1",
-      [[""], ["3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501"], ["304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301"], 1], "PUSH DATA 635221022d73c0041da9794fcaa7286fcce35e126f84f8b53563be6abb3b213f964bfbfc2102ab2445a289939e49e326dd29ca068cb38d1c9ef7618b7272d14c79c1abdea5cd52ae675221025182b1ca9a1ea9358f61cb363ac80c80b145204d9c4d875c35873d3d578853",
-      [[""], ["3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501"], ["304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301"], 1, ["635221022d73c0041da9794fcaa7286fcce35e126f84f8b53563be6abb3b213f964bfbfc2102ab2445a289939e49e326dd29ca068cb38d1c9ef7618b7272d14c79c1abdea5cd52ae675221025182b1ca9a1ea9358f61cb363ac80c80b145204d9c4d875c35873d3d578853"]], "OP_IF",
-
-      [[""], ["3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501"], ["304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301"], 1], "OP_2",
-      [[""], ["3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501"], ["304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301"], 1, 2], "PUSH DATA 022d73c0041da9794fcaa7286fcce35e126f84f8b53563be6abb3b213f964bfbfc",
-      [[""], ["3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501"], ["304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301"], 1, 2, ["022d73c0041da9794fcaa7286fcce35e126f84f8b53563be6abb3b213f964bfbfc"]], "PUSH DATA 02ab2445a289939e49e326dd29ca068cb38d1c9ef7618b7272d14c79c1abdea5cd",
-      [[""], ["3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501"], ["304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301"], 1, 2, ["022d73c0041da9794fcaa7286fcce35e126f84f8b53563be6abb3b213f964bfbfc"], ["02ab2445a289939e49e326dd29ca068cb38d1c9ef7618b7272d14c79c1abdea5cd"]], "OP_2",
-      [[""], ["3045022041ccefcad804c28fcd843afeb10df3bd09d93e56542cda4ae9bcac18ed69f6c7022100f24d891b69695099a66b81a4ef382ff0ef388ad211505cd32e2ad3adebe5f74501"], ["304502201124a34c8bcc6a41c9bda088bc28e4274af02872866fa926205b0799e0f3b28a022100d0bbe8382a4e6ff46968bb8c2990bb63ef7f413f5b7c3912b4948b3eb0e72fc301"], 1, 2, ["022d73c0041da9794fcaa7286fcce35e126f84f8b53563be6abb3b213f964bfbfc"], ["02ab2445a289939e49e326dd29ca068cb38d1c9ef7618b7272d14c79c1abdea5cd"], 2], "OP_CHECKMULTISIG",
-      [[""], 0], "OP_ELSE",
-      [[""], 0], "OP_ENDIF",
-      [[""], 0], "RESULT"]
-  end
-
-  it "should not execute p2sh recursively" do
-    # this script_sig includes a pattern that matches the p2sh template
-    script_sig = "0 a914b472a266d0bd89c13706a4132ccfb16f7c3b9fcb87"
-    pk_script = "OP_HASH160 92a04bc86e23f169691bd6926d11853cc61e1852 OP_EQUAL"
-    script = Bitcoin::Script.from_string(script_sig + " " + pk_script)
-    script.run.should == true
-  end
-
-  def build_p2sh_multisig_tx(m, *keys)
-    redeem_script = Bitcoin::Script.to_multisig_script(m, *keys.map(&:pub))
-    p2sh_address = Bitcoin.hash160_to_p2sh_address(Bitcoin.hash160(redeem_script.hth))
-
-    prev_tx = build_tx {|t| t.input {|i| i.coinbase}
-      t.output {|o| o.to p2sh_address; o.value 50e8 } }
-    tx = build_tx {|t| t.input {|i| i.prev_out prev_tx, 0 }
-      t.output {|o| o.to Bitcoin::Key.generate.addr; o.value 50e8 } }
-
-    sig_hash = tx.signature_hash_for_input(0, redeem_script)
-    return prev_tx, tx, redeem_script, sig_hash
-  end
-
-  it "#sort_p2sh_multisig_signatures 3-of-3" do
-    keys = 3.times.map { Bitcoin::Key.generate }
-
-    prev_tx, tx, redeem_script, sig_hash = build_p2sh_multisig_tx(3, *keys)
-    sigs = keys.map {|k| k.sign(sig_hash) }
-
-    # add sigs in all possible orders, sort them, and see if they are valid
-    [0, 1, 2].permutation do |order|
-      script_sig = Script.to_p2sh_multisig_script_sig(redeem_script)
-      order.each{|i| script_sig = Script.add_sig_to_multisig_script_sig(sigs[i], script_sig)}
-      script_sig = Script.sort_p2sh_multisig_signatures(script_sig, sig_hash)
-      tx.in[0].script_sig = script_sig
-      tx.verify_input_signature(0, prev_tx).should == true
+      Bitcoin::Script::is_low_der_signature?(sig.pack("C*")).should == false
     end
+    it 'enforces rules 3 and 4' do
+        Script.new([75].pack("C") + 'A' * 75).pushes_are_canonical?.should == true
+        Script.new([Bitcoin::Script::OP_PUSHDATA1, 75].pack("CC") + 'A' * 75).pushes_are_canonical?.should == false
+        Script.new([Bitcoin::Script::OP_PUSHDATA2, 255].pack("Cv") + 'A' * 255).pushes_are_canonical?.should == false
+        Script.new([Bitcoin::Script::OP_PUSHDATA4, 1645].pack("CV") + 'A' * 1645).pushes_are_canonical?.should == false
+      end
   end
 
-  it "#sort_p2sh_multisig_signatures 2-of-3" do
-    keys = 3.times.map { Bitcoin::Key.generate }
-
-    prev_tx, tx, redeem_script, sig_hash = build_p2sh_multisig_tx(2, *keys)
-    sigs = keys.map {|k| k.sign(sig_hash) }
-
-    # add sigs in all possible orders, sort them, and see if they are valid
-    [0, 1, 2].permutation(2) do |order|
-      script_sig = Script.to_p2sh_multisig_script_sig(redeem_script)
-      order.each{|i| script_sig = Script.add_sig_to_multisig_script_sig(sigs[i], script_sig)}
-      script_sig = Script.sort_p2sh_multisig_signatures(script_sig, sig_hash)
-      tx.in[0].script_sig = script_sig
-      tx.verify_input_signature(0, prev_tx).should == true
+  describe "Implements BIP66" do
+    def build_crediting_tx(script_pk)
+      tx = Bitcoin::P::Tx.new
+      input = Bitcoin::P::TxIn.new(nil, 0xffffffff, 2, "\x00\x00")
+      output = Bitcoin::P::TxOut.new(0, script_pk)
+      tx.add_in(input)
+      tx.add_out(output)
+      Bitcoin::P::Tx.new(tx.to_payload)
     end
-  end
 
-end
-
-describe "Implements BIP62" do
-  it 'tests for incorrectly encoded S-values in signatures' do
-    # TX 3da75972766f0ad13319b0b461fd16823a731e44f6e9de4eb3c52d6a6fb6c8ae
-    sig_orig = ["304502210088984573e3e4f33db7df6aea313f1ce67a3ef3532ea89991494c7f018258371802206ceefc9291450dbd40d834f249658e0f64662d52a41cf14e20c9781144f2fe0701"].pack("H*")
-    Bitcoin::Script::is_low_der_signature?(sig_orig).should == true
-
-    # Set the start of the S-value to 0xff so it's well above the order of the curve divided by two
-    sig = sig_orig.unpack("C*")
-    length_r = sig[3]
-    sig[6 + length_r] = 0xff
-
-    Bitcoin::Script::is_low_der_signature?(sig.pack("C*")).should == false
-  end
-  it 'enforces rules 3 and 4' do
-      Script.new([75].pack("C") + 'A' * 75).pushes_are_canonical?.should == true
-      Script.new([Bitcoin::Script::OP_PUSHDATA1, 75].pack("CC") + 'A' * 75).pushes_are_canonical?.should == false
-      Script.new([Bitcoin::Script::OP_PUSHDATA2, 255].pack("Cv") + 'A' * 255).pushes_are_canonical?.should == false
-      Script.new([Bitcoin::Script::OP_PUSHDATA4, 1645].pack("CV") + 'A' * 1645).pushes_are_canonical?.should == false
+    def build_spending_tx(script_sig, tx_credit)
+      tx = Bitcoin::P::Tx.new
+      input = Bitcoin::P::TxIn.new(tx_credit.binary_hash, 0, 2, script_sig)
+      output = Bitcoin::P::TxOut.new(0, '')
+      tx.add_in(input)
+      tx.add_out(output)
+      Bitcoin::P::Tx.new(tx.to_payload)
     end
-end
 
-describe "Implements BIP66" do
-  def build_crediting_tx(script_pk)
-    tx = Bitcoin::P::Tx.new
-    input = Bitcoin::P::TxIn.new(nil, 0xffffffff, 2, "\x00\x00")
-    output = Bitcoin::P::TxOut.new(0, script_pk)
-    tx.add_in(input)
-    tx.add_out(output)
-    Bitcoin::P::Tx.new(tx.to_payload)
-  end
+    # essentially DoTest() from script_tests.cpp
+    def run_script_test(script_sig_str, script_pk_str, opts={})
+      script_sig = Bitcoin::Script.from_string(script_sig_str)
+      script_pk = Bitcoin::Script.from_string(script_pk_str)
+      tx_credit = build_crediting_tx(script_pk.raw)
+      tx = build_spending_tx(script_sig.raw, tx_credit)
+      tx.verify_input_signature(0, tx_credit, Time.now.to_i, opts)
+    end
 
-  def build_spending_tx(script_sig, tx_credit)
-    tx = Bitcoin::P::Tx.new
-    input = Bitcoin::P::TxIn.new(tx_credit.binary_hash, 0, 2, script_sig)
-    output = Bitcoin::P::TxOut.new(0, '')
-    tx.add_in(input)
-    tx.add_out(output)
-    Bitcoin::P::Tx.new(tx.to_payload)
-  end
+    it 'overly long signature fails with DERSIG passes without' do
+      script_sig = "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+      script_pk = "0 OP_CHECKSIG OP_NOT"
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
+      run_script_test(script_sig, script_pk).should == true
+    end
 
-  # essentially DoTest() from script_tests.cpp
-  def run_script_test(script_sig_str, script_pk_str, opts={})
-    script_sig = Bitcoin::Script.from_string(script_sig_str)
-    script_pk = Bitcoin::Script.from_string(script_pk_str)
-    tx_credit = build_crediting_tx(script_pk.raw)
-    tx = build_spending_tx(script_sig.raw, tx_credit)
-    tx.verify_input_signature(0, tx_credit, Time.now.to_i, opts)
-  end
+    it 'missing S fails with DERSIG passes without' do
+      script_sig = "3022022000000000000000000000000000000000000000000000000000000000000000000"
+      script_pk = "0 OP_CHECKSIG OP_NOT"
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
+      run_script_test(script_sig, script_pk).should == true
+    end
 
-  it 'overly long signature fails with DERSIG passes without' do
-    script_sig = "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-    script_pk = "0 OP_CHECKSIG OP_NOT"
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
-    run_script_test(script_sig, script_pk).should == true
-  end
+    it 'S with invalid fails with DERSIG passes without' do
+      script_sig = "3024021077777777777777777777777777777777020a7777777777777777777777777777777701"
+      script_pk = "0 OP_CHECKSIG OP_NOT"
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
+      run_script_test(script_sig, script_pk).should == true
+    end
 
-  it 'missing S fails with DERSIG passes without' do
-    script_sig = "3022022000000000000000000000000000000000000000000000000000000000000000000"
-    script_pk = "0 OP_CHECKSIG OP_NOT"
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
-    run_script_test(script_sig, script_pk).should == true
-  end
+    it 'non-integer R fails with DERSIG passes without' do
+      script_sig = "302403107777777777777777777777777777777702107777777777777777777777777777777701"
+      script_pk = "0 OP_CHECKSIG OP_NOT"
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
+      run_script_test(script_sig, script_pk).should == true
+    end
 
-  it 'S with invalid fails with DERSIG passes without' do
-    script_sig = "3024021077777777777777777777777777777777020a7777777777777777777777777777777701"
-    script_pk = "0 OP_CHECKSIG OP_NOT"
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
-    run_script_test(script_sig, script_pk).should == true
-  end
+    it 'non-integer S fails with DERSIG passes without' do
+      script_sig = "302402107777777777777777777777777777777703107777777777777777777777777777777701"
+      script_pk = "0 OP_CHECKSIG OP_NOT"
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
+      run_script_test(script_sig, script_pk).should == true
+    end
 
-  it 'non-integer R fails with DERSIG passes without' do
-    script_sig = "302403107777777777777777777777777777777702107777777777777777777777777777777701"
-    script_pk = "0 OP_CHECKSIG OP_NOT"
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
-    run_script_test(script_sig, script_pk).should == true
-  end
+    it 'zero length R fails with DERSIG passes without' do
+      script_sig = "3014020002107777777777777777777777777777777701"
+      script_pk = "0 OP_CHECKSIG OP_NOT"
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
+      run_script_test(script_sig, script_pk).should == true
+    end
 
-  it 'non-integer S fails with DERSIG passes without' do
-    script_sig = "302402107777777777777777777777777777777703107777777777777777777777777777777701"
-    script_pk = "0 OP_CHECKSIG OP_NOT"
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
-    run_script_test(script_sig, script_pk).should == true
-  end
+    it 'zero length S fails with DERSIG passes without' do
+      script_sig = "3014021077777777777777777777777777777777020001"
+      script_pk = "0 OP_CHECKSIG OP_NOT"
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
+      run_script_test(script_sig, script_pk).should == true
+    end
 
-  it 'zero length R fails with DERSIG passes without' do
-    script_sig = "3014020002107777777777777777777777777777777701"
-    script_pk = "0 OP_CHECKSIG OP_NOT"
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
-    run_script_test(script_sig, script_pk).should == true
-  end
+    it 'negative S fails with DERSIG passes without' do
+      script_sig = "302402107777777777777777777777777777777702108777777777777777777777777777777701"
+      script_pk = "0 OP_CHECKSIG OP_NOT"
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
+      run_script_test(script_sig, script_pk).should == true
+    end
 
-  it 'zero length S fails with DERSIG passes without' do
-    script_sig = "3014021077777777777777777777777777777777020001"
-    script_pk = "0 OP_CHECKSIG OP_NOT"
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
-    run_script_test(script_sig, script_pk).should == true
-  end
+    # see: https://github.com/bitcoin/bips/blob/master/bip-0066.mediawiki#examples
+    # see also: https://github.com/bitcoin/bitcoin/pull/5713/files
+    P1 = "038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508"
+    P2 = "03363d90d447b00c9c99ceac05b6262ee053441c7e55552ffe526bad8f83ff4640"
 
-  it 'negative S fails with DERSIG passes without' do
-    script_sig = "302402107777777777777777777777777777777702108777777777777777777777777777777701"
-    script_pk = "0 OP_CHECKSIG OP_NOT"
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
-    run_script_test(script_sig, script_pk).should == true
-  end
+    # Example 1: S1' P1 CHECKSIG (fails w/ verify_dersig, passes w/o)
+    it 'example 1' do
+      script_sig = "30440220d7a0417c3f6d1a15094d1cf2a3378ca0503eb8a57630953a9e2987e21ddd0a6502207a6266d686c99090920249991d3d42065b6d43eb70187b219c0db82e4f94d1a201"
+      script_pk = "#{P1} OP_CHECKSIG"
+      run_script_test(script_sig, script_pk).should == true
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
+    end
 
-  # see: https://github.com/bitcoin/bips/blob/master/bip-0066.mediawiki#examples
-  # see also: https://github.com/bitcoin/bitcoin/pull/5713/files
-  P1 = "038282263212c609d9ea2a6e3e172de238d8c39cabd5ac1ca10646e23fd5f51508"
-  P2 = "03363d90d447b00c9c99ceac05b6262ee053441c7e55552ffe526bad8f83ff4640"
+    # Example 2: S1' P1 CHECKSIG NOT (fails with either)
+    it 'example 2' do
+      script_sig = "304402208e43c0b91f7c1e5bc58e41c8185f8a6086e111b0090187968a86f2822462d3c902200a58f4076b1133b18ff1dc83ee51676e44c60cc608d9534e0df5ace0424fc0be01"
+      script_pk = "#{P1} OP_CHECKSIG OP_NOT"
+      run_script_test(script_sig, script_pk).should == false
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
+    end
 
-  # Example 1: S1' P1 CHECKSIG (fails w/ verify_dersig, passes w/o)
-  it 'example 1' do
-    script_sig = "30440220d7a0417c3f6d1a15094d1cf2a3378ca0503eb8a57630953a9e2987e21ddd0a6502207a6266d686c99090920249991d3d42065b6d43eb70187b219c0db82e4f94d1a201"
-    script_pk = "#{P1} OP_CHECKSIG"
-    run_script_test(script_sig, script_pk).should == true
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
-  end
+    # Example 3: F P1 CHECKSIG fails (fails with either)
+    it 'example 3' do
+      script_sig = "0"
+      script_pk = "#{P1} OP_CHECKSIG"
+      run_script_test(script_sig, script_pk).should == false
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
+    end
 
-  # Example 2: S1' P1 CHECKSIG NOT (fails with either)
-  it 'example 2' do
-    script_sig = "304402208e43c0b91f7c1e5bc58e41c8185f8a6086e111b0090187968a86f2822462d3c902200a58f4076b1133b18ff1dc83ee51676e44c60cc608d9534e0df5ace0424fc0be01"
-    script_pk = "#{P1} OP_CHECKSIG OP_NOT"
-    run_script_test(script_sig, script_pk).should == false
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
-  end
+    # Example 4: F P1 CHECKSIG NOT (passes with either)
+    it 'example 4' do
+      script_sig = "0"
+      script_pk = "#{P1} OP_CHECKSIG OP_NOT"
+      run_script_test(script_sig, script_pk).should == true
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == true
+    end
 
-  # Example 3: F P1 CHECKSIG fails (fails with either)
-  it 'example 3' do
-    script_sig = "0"
-    script_pk = "#{P1} OP_CHECKSIG"
-    run_script_test(script_sig, script_pk).should == false
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
-  end
+    # Example 5: F' P1 CHECKSIG (fails with either)
+    it 'example 5' do
+      script_sig = "1"
+      script_pk = "#{P1} OP_CHECKSIG"
+      run_script_test(script_sig, script_pk).should == false
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
+    end
 
-  # Example 4: F P1 CHECKSIG NOT (passes with either)
-  it 'example 4' do
-    script_sig = "0"
-    script_pk = "#{P1} OP_CHECKSIG OP_NOT"
-    run_script_test(script_sig, script_pk).should == true
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == true
-  end
+    # Example 6: F' P1 CHECKSIG NOT (fails w/verify_dersig, passes w/o)
+    it 'example 6' do
+      script_sig = "1"
+      script_pk = "#{P1} OP_CHECKSIG OP_NOT"
+      run_script_test(script_sig, script_pk).should == true
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
+    end
 
-  # Example 5: F' P1 CHECKSIG (fails with either)
-  it 'example 5' do
-    script_sig = "1"
-    script_pk = "#{P1} OP_CHECKSIG"
-    run_script_test(script_sig, script_pk).should == false
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
-  end
+    # Example 7: 0 S1' S2 2 P1 P2 2 CHECKMULTISIG (fails w/verify_dersig, passes w/o)
+    it 'example 7' do
+      s1 = "30440220cae00b1444babfbf6071b0ba8707f6bd373da3df494d6e74119b0430c5db810502205d5231b8c5939c8ff0c82242656d6e06edb073d42af336c99fe8837c36ea39d501"
+      s2 = "304402200b3d0b0375bb15c14620afa4aa10ae90a0d6a046ce217bc20fe0bc1ced68c1b802204b550acab90ae6d3478057c9ad24f9df743815b799b6449dd7e7f6d3bc6e274c01"
+      script_sig = "0 #{s1} #{s2}"
+      script_pk = "2 #{P1} #{P2} 2 OP_CHECKMULTISIG"
+      run_script_test(script_sig, script_pk).should == true
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
+    end
 
-  # Example 6: F' P1 CHECKSIG NOT (fails w/verify_dersig, passes w/o)
-  it 'example 6' do
-    script_sig = "1"
-    script_pk = "#{P1} OP_CHECKSIG OP_NOT"
-    run_script_test(script_sig, script_pk).should == true
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
-  end
+    # Example 8: 0 S1' S2 2 P1 P2 2 CHECKMULTISIG NOT (fails for either)
+    it 'example 8' do
+      s1 = "30440220f00a77260d34ec2f0c59621dc710f58169d0ca06df1a88cd4b1f1b97bd46991b02201ee220c7e04f26aed03f94aa97fb09ca5627163bf4ba07e6979972ec737db22601"
+      s2 = "3044022079ea80afd538d9ada421b5101febeb6bc874e01dde5bca108c1d0479aec339a4022004576db8f66130d1df686ccf00935703689d69cf539438da1edab208b0d63c4801"
+      script_sig = "0 #{s1} #{s2}"
+      script_pk = "2 #{P1} #{P2} 2 OP_CHECKMULTISIG OP_NOT"
+      run_script_test(script_sig, script_pk).should == false
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
+    end
 
-  # Example 7: 0 S1' S2 2 P1 P2 2 CHECKMULTISIG (fails w/verify_dersig, passes w/o)
-  it 'example 7' do
-    s1 = "30440220cae00b1444babfbf6071b0ba8707f6bd373da3df494d6e74119b0430c5db810502205d5231b8c5939c8ff0c82242656d6e06edb073d42af336c99fe8837c36ea39d501"
-    s2 = "304402200b3d0b0375bb15c14620afa4aa10ae90a0d6a046ce217bc20fe0bc1ced68c1b802204b550acab90ae6d3478057c9ad24f9df743815b799b6449dd7e7f6d3bc6e274c01"
-    script_sig = "0 #{s1} #{s2}"
-    script_pk = "2 #{P1} #{P2} 2 OP_CHECKMULTISIG"
-    run_script_test(script_sig, script_pk).should == true
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
-  end
+    # Example 9: 0 F S2' 2 P1 P2 2 CHECKMULTISIG fails (fails for either)
+    it 'example 9' do
+      s1 = "0"
+      s2 = "3044022081aa9d436f2154e8b6d600516db03d78de71df685b585a9807ead4210bd883490220534bb6bdf318a419ac0749660b60e78d17d515558ef369bf872eff405b676b2e01"
+      script_sig = "0 #{s1} #{s2}"
+      script_pk = "2 #{P1} #{P2} 2 OP_CHECKMULTISIG"
+      run_script_test(script_sig, script_pk).should == false
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
+    end
 
-  # Example 8: 0 S1' S2 2 P1 P2 2 CHECKMULTISIG NOT (fails for either)
-  it 'example 8' do
-    s1 = "30440220f00a77260d34ec2f0c59621dc710f58169d0ca06df1a88cd4b1f1b97bd46991b02201ee220c7e04f26aed03f94aa97fb09ca5627163bf4ba07e6979972ec737db22601"
-    s2 = "3044022079ea80afd538d9ada421b5101febeb6bc874e01dde5bca108c1d0479aec339a4022004576db8f66130d1df686ccf00935703689d69cf539438da1edab208b0d63c4801"
-    script_sig = "0 #{s1} #{s2}"
-    script_pk = "2 #{P1} #{P2} 2 OP_CHECKMULTISIG OP_NOT"
-    run_script_test(script_sig, script_pk).should == false
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
-  end
+    # Example 10: 0 F S2' 2 P1 P2 2 CHECKMULTISIG NOT (fails w/verify_dersig, passes w/o)
+    it 'example 10' do
+      s1 = "0"
+      s2 = "30440220afa76a8f60622f813b05711f051c6c3407e32d1b1b70b0576c1f01b54e4c05c702200d58e9df044fd1845cabfbeef6e624ba0401daf7d7e084736f9ff601c3783bf501"
+      script_sig = "0 #{s1} #{s2}"
+      script_pk = "2 #{P1} #{P2} 2 OP_CHECKMULTISIG OP_NOT"
+      run_script_test(script_sig, script_pk).should == true
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
+    end
 
-  # Example 9: 0 F S2' 2 P1 P2 2 CHECKMULTISIG fails (fails for either)
-  it 'example 9' do
-    s1 = "0"
-    s2 = "3044022081aa9d436f2154e8b6d600516db03d78de71df685b585a9807ead4210bd883490220534bb6bdf318a419ac0749660b60e78d17d515558ef369bf872eff405b676b2e01"
-    script_sig = "0 #{s1} #{s2}"
-    script_pk = "2 #{P1} #{P2} 2 OP_CHECKMULTISIG"
-    run_script_test(script_sig, script_pk).should == false
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
-  end
+    # Example 11: 0 S1' F 2 P1 P2 2 CHECKMULTISIG (fails for either)
+    it 'example 11' do
+      s1 = "30440220cae00b1444babfbf6071b0ba8707f6bd373da3df494d6e74119b0430c5db810502205d5231b8c5939c8ff0c82242656d6e06edb073d42af336c99fe8837c36ea39d501"
+      s2 = "0"
+      script_sig = "0 #{s1} #{s2}"
+      script_pk = "2 #{P1} #{P2} 2 OP_CHECKMULTISIG"
+      run_script_test(script_sig, script_pk).should == false
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
+    end
 
-  # Example 10: 0 F S2' 2 P1 P2 2 CHECKMULTISIG NOT (fails w/verify_dersig, passes w/o)
-  it 'example 10' do
-    s1 = "0"
-    s2 = "30440220afa76a8f60622f813b05711f051c6c3407e32d1b1b70b0576c1f01b54e4c05c702200d58e9df044fd1845cabfbeef6e624ba0401daf7d7e084736f9ff601c3783bf501"
-    script_sig = "0 #{s1} #{s2}"
-    script_pk = "2 #{P1} #{P2} 2 OP_CHECKMULTISIG OP_NOT"
-    run_script_test(script_sig, script_pk).should == true
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
-  end
-
-  # Example 11: 0 S1' F 2 P1 P2 2 CHECKMULTISIG (fails for either)
-  it 'example 11' do
-    s1 = "30440220cae00b1444babfbf6071b0ba8707f6bd373da3df494d6e74119b0430c5db810502205d5231b8c5939c8ff0c82242656d6e06edb073d42af336c99fe8837c36ea39d501"
-    s2 = "0"
-    script_sig = "0 #{s1} #{s2}"
-    script_pk = "2 #{P1} #{P2} 2 OP_CHECKMULTISIG"
-    run_script_test(script_sig, script_pk).should == false
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == false
-  end
-
-  # Example 12: 0 S1' F 2 P1 P2 2 CHECKMULTISIG NOT (passes for either)
-  it 'example 12' do
-    s1 = "30440220f00a77260d34ec2f0c59621dc710f58169d0ca06df1a88cd4b1f1b97bd46991b02201ee220c7e04f26aed03f94aa97fb09ca5627163bf4ba07e6979972ec737db22601"
-    s2 = "0"
-    script_sig = "0 #{s1} #{s2}"
-    script_pk = "2 #{P1} #{P2} 2 OP_CHECKMULTISIG OP_NOT"
-    run_script_test(script_sig, script_pk).should == true
-    run_script_test(script_sig, script_pk, {verify_dersig: true}).should == true
+    # Example 12: 0 S1' F 2 P1 P2 2 CHECKMULTISIG NOT (passes for either)
+    it 'example 12' do
+      s1 = "30440220f00a77260d34ec2f0c59621dc710f58169d0ca06df1a88cd4b1f1b97bd46991b02201ee220c7e04f26aed03f94aa97fb09ca5627163bf4ba07e6979972ec737db22601"
+      s2 = "0"
+      script_sig = "0 #{s1} #{s2}"
+      script_pk = "2 #{P1} #{P2} 2 OP_CHECKMULTISIG OP_NOT"
+      run_script_test(script_sig, script_pk).should == true
+      run_script_test(script_sig, script_pk, {verify_dersig: true}).should == true
+    end
   end
 end


### PR DESCRIPTION
Wrap the specs in the relevant module's namespace, rather than including that module into the global scope.
