### PR TITLE
Call 'to_s' before 'gsub' in TxOut.from_hash

### DIFF
--- a/lib/bitcoin/protocol/txout.rb
+++ b/lib/bitcoin/protocol/txout.rb
@@ -14,7 +14,7 @@ module Bitcoin
       # p2sh redeem script (optional, not included in the serialized binary format)
       attr_accessor :redeem_script
 
-      def initialize *args
+      def initialize(*args)
         if args.size == 2
           @value, @pk_script_length, @pk_script = args[0], args[1].bytesize, args[1]
         else
@@ -66,7 +66,7 @@ module Bitcoin
       end
 
       def self.from_hash(output)
-        amount = output['value'] ? output['value'].gsub('.','').to_i : output['amount']
+        amount = output['value'] ? output['value'].to_s.gsub('.','').to_i : output['amount']
         script = Script.binary_from_string(output['scriptPubKey'] || output['script'])
         new(amount, script)
       end

--- a/spec/bitcoin/protocol/txout_spec.rb
+++ b/spec/bitcoin/protocol/txout_spec.rb
@@ -23,5 +23,26 @@ describe 'TxOut' do
     (o1 == nil).should == false
   end
 
-end
+  describe ".from_hash" do
+    before do
+      @hash = {
+        "spent"    => false,
+        "tx_index" => 101431844,
+        "type"     => 0,
+        "addr"     => "1Az1Sh9Tai6gFfEzFczhHY27WiQ99ZZURtA",
+        "value"    => "1234",
+        "n"        => 0,
+        "script"   => "d6c66cd822a22d7da0ce388589bb161d8667e40e5279f20fd2"
+      }
+      @script = Bitcoin::Script.binary_from_string(@hash["script"])
+    end
 
+    it "creates a new TxOut from the hash" do
+      txout = TxOut.from_hash(@hash)
+      txout.value.should            == 1234
+      txout.pk_script               == @script
+      txout.pk_script_length.should == @script.bytesize
+    end
+
+  end
+end

--- a/spec/bitcoin/protocol/txout_spec.rb
+++ b/spec/bitcoin/protocol/txout_spec.rb
@@ -44,5 +44,13 @@ describe 'TxOut' do
       txout.pk_script_length.should == @script.bytesize
     end
 
+    it "hash['value'] can be an integer" do
+      @hash["value"] = 1234
+      txout = TxOut.from_hash(@hash)
+      txout.value.should            == 1234
+      txout.pk_script               == @script
+      txout.pk_script_length.should == @script.bytesize
+    end
+
   end
 end


### PR DESCRIPTION
Don't assume that `'value'` is already a String. E.g., when I pull transaction data from the blockchain.info API, the value will be an Integer, which can cause an error:

```
require 'bitcoin'
require 'httparty'

data = HTTParty.get("https://blockchain.info/rawtx/248512ccf8d225798ae1b82839e92bdae315e7bfb9afcb719b2ad0152eda3f1d").parsed_response
tx = Bitcoin::Protocol::Transaction.from_hash(data)

# => NoMethodError: undefined method `gsub' for 10000:Fixnum
```

Added a spec for the existing `from_hash` behaviour while I was at it ;)
