### PR TITLE
AuxPow: clean up naming, store branch hashes in hex

### DIFF
--- a/lib/bitcoin/protocol/aux_pow.rb
+++ b/lib/bitcoin/protocol/aux_pow.rb
@@ -4,25 +4,40 @@ module Bitcoin
   module Protocol
 
     # Auxiliary Proof-of-Work for merge-mined blockchains
+    # See https://en.bitcoin.it/wiki/Merged_mining_specification.
+    #
+    # The AuxPow contains all data needed to verify that the child
+    # block was included in the parents coinbase transaction, and
+    # the parent satisfies the difficulty target.
+    #
+    # It encodes the +parent_block+ header, and its +coinbase_tx+.
+    # The +coinbase_branch+ and +coinbase_index+ can be used to recalculate
+    # the parent blocks merkle root and prove the coinbase transaction is
+    # really included in it.
+    # The +chain_branch+ and +chain_index+ are used to link the child block
+    # to the merkle root contained in the +coinbase_tx+. (So there can be
+    # more than one merge-mined chain)
+    #
+    # TODO: decode merged-mining data from +coinbase_tx+
     class AuxPow
 
-      # Coinbase transaction linking the aux to its parent block
-      attr_accessor :tx
+      # Coinbase transaction of the parent block, linking to the child block
+      attr_accessor :coinbase_tx
 
-      # Hash of the block header
+      # Hash of the parent block header
       attr_accessor :block_hash
 
-      # Merkle branches to bring the transaction to the block's merkle root
-      attr_accessor :branch
+      # Merkle branch linking the +coinbase_tx+ to the +parent_block+
+      attr_accessor :coinbase_branch
 
-      # Index of this transaction in the merkle tree
-      attr_accessor :mrkl_index
+      # Index of the +coinbase_tx+ in the parent blocks merkle tree
+      attr_accessor :coinbase_index
 
-      # Merkle branches linking this aux chains to the aux root
-      attr_accessor :aux_branch
+      # Merkle branch linking the child block to the +coinbase_tx+
+      attr_accessor :chain_branch
 
-      # Index of "this" block chain in the aux chain list
-      attr_accessor :aux_index
+      # Index of the child block in the chain merkle tree
+      attr_accessor :chain_index
 
       # Parent block header
       attr_accessor :parent_block
@@ -38,26 +53,26 @@ module Bitcoin
       end
 
       def parse_data_from_io(data)
-        @tx = P::Tx.new(nil)
-        @tx.parse_data_from_io(data)
+        @coinbase_tx = P::Tx.new(nil)
+        @coinbase_tx.parse_data_from_io(data)
 
         @block_hash = data.read(32)
-        branch_count = P.unpack_var_int_from_io(data)
-        @branch = []
-        branch_count.times{
+        coinbase_branch_count = P.unpack_var_int_from_io(data)
+        @coinbase_branch = []
+        coinbase_branch_count.times{
           break if data.eof?
-          @branch << data.read(32)
+          @coinbase_branch << data.read(32).reverse.hth
         }
-        @mrkl_index = data.read(4).unpack("I")[0]
+        @coinbase_index = data.read(4).unpack("I")[0]
 
-        @aux_branch = []
-        aux_branch_count = P.unpack_var_int_from_io(data)
-        aux_branch_count.times{
+        @chain_branch = []
+        chain_branch_count = P.unpack_var_int_from_io(data)
+        chain_branch_count.times{
           break if data.eof?
-          @aux_branch << data.read(32)
+          @chain_branch << data.read(32).reverse.hth
         }
 
-        @aux_index = data.read(4).unpack("I")[0]
+        @chain_index = data.read(4).unpack("I")[0]
         block = data.read(80)
         @parent_block = P::Block.new(block)
 
@@ -66,14 +81,14 @@ module Bitcoin
 
 
       def to_payload
-        payload = @tx.to_payload
+        payload = @coinbase_tx.to_payload
         payload << @block_hash
-        payload << P.pack_var_int(@branch.count)
-        payload << @branch.join
-        payload << [@mrkl_index].pack("I")
-        payload << P.pack_var_int(@aux_branch.count)
-        payload << @aux_branch.join
-        payload << [@aux_index].pack("I")
+        payload << P.pack_var_int(@coinbase_branch.count)
+        payload << @coinbase_branch.map(&:htb).map(&:reverse).join
+        payload << [@coinbase_index].pack("I")
+        payload << P.pack_var_int(@chain_branch.count)
+        payload << @chain_branch.map(&:htb).map(&:reverse).join
+        payload << [@chain_index].pack("I")
         payload << @parent_block.to_payload
         payload
       end
@@ -81,24 +96,24 @@ module Bitcoin
       def self.from_hash h
         aux_pow = new(nil)
         aux_pow.instance_eval do
-          @tx = P::Tx.from_hash(h['tx'])
+          @coinbase_tx = P::Tx.from_hash(h['coinbase_tx'])
           @block_hash = h['block_hash'].htb
-          @branch = h['branch'].map(&:htb)
-          @mrkl_index = h['mrkl_index']
-          @aux_branch = h['aux_branch'].map(&:htb)
-          @aux_index = h['aux_index']
+          @coinbase_branch = h['coinbase_branch']
+          @coinbase_index = h['coinbase_index']
+          @chain_branch = h['chain_branch']
+          @chain_index = h['chain_index']
           @parent_block = P::Block.from_hash(h['parent_block'])
         end
         aux_pow
       end
 
       def to_hash
-        { 'tx' => @tx.to_hash,
+        { 'coinbase_tx' => @coinbase_tx.to_hash,
           'block_hash' => @block_hash.hth,
-          'branch' => @branch.map(&:hth),
-          'mrkl_index' => @mrkl_index,
-          'aux_branch' => @aux_branch.map(&:hth),
-          'aux_index' => @aux_index,
+          'coinbase_branch' => @coinbase_branch,
+          'coinbase_index' => @coinbase_index,
+          'chain_branch' => @chain_branch,
+          'chain_index' => @chain_index,
           'parent_block' => @parent_block.to_hash }
       end
 

--- a/spec/bitcoin/protocol/aux_pow_spec.rb
+++ b/spec/bitcoin/protocol/aux_pow_spec.rb
@@ -17,14 +17,14 @@ describe Bitcoin::Protocol::AuxPow do
     @aux_pow.should != nil
     @aux_pow.block_hash.hth.should ==
       "b42124fd99e67ddabe52ebbfcb30a82b8c74268a320b3c5e2311000000000000"
-    @aux_pow.branch.map(&:hth).should == [
-      "6d4febe909ffec61fb8e7bf24ef4444f070f74b208502285528a9686ba792fc2",
-      "d052728459450cec6ff81072c6bd3ec2fd186eaadb09429da7cab0be73646999",
-      "64c5e7e42a6cde585602fdfda6d7e5d9232db2c176a49278268cec09f3cfcb20",
-      "4e9406d6ce9ef751242bb9a63e7c2009746b3736c356ed5d738dadd6937531e4" ]
-    @aux_pow.mrkl_index.should == 0
-    @aux_pow.aux_branch.should == []
-    @aux_pow.aux_index.should == 0
+    @aux_pow.coinbase_branch.should == [
+      "c22f79ba86968a5285225008b2740f074f44f44ef27b8efb61ecff09e9eb4f6d",
+      "99696473beb0caa79d4209dbaa6e18fdc23ebdc67210f86fec0c4559847252d0",
+      "20cbcff309ec8c267892a476c1b22d23d9e5d7a6fdfd025658de6c2ae4e7c564",
+      "e4317593d6ad8d735ded56c336376b7409207c3ea6b92b2451f79eced606944e" ]
+    @aux_pow.coinbase_index.should == 0
+    @aux_pow.chain_branch.should == []
+    @aux_pow.chain_index.should == 0
     @aux_pow.parent_block.hash.should ==
       "00000000000011235e3c0b328a26748c2ba830cbbfeb52beda7de699fd2421b4"
   end
@@ -42,4 +42,4 @@ describe Bitcoin::Protocol::AuxPow do
     P::Block.from_json(@blk.to_json).to_payload.should == @data
   end
 
-  end
+end


### PR DESCRIPTION
According to https://en.bitcoin.it/wiki/Merged_mining_specification

IMHO this makes it much easier to grasp what the AuxPow data really is, and how it is supposed to be used. Also to talk about it with others ;)

@rnicoll are the changes OK with you?