### PR TITLE
Always force_encode message to binary in Bitcoin.sign_message.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,14 @@ GEM
   remote: http://rubygems.org/
   specs:
     bacon (1.2.0)
-    eventmachine (1.0.7)
-    ffi (1.9.8)
+    eventmachine (1.0.8)
+    ffi (1.9.10)
     ffi-compiler (0.1.3)
       ffi (>= 1.0.0)
       rake
-    minitest (5.7.0)
+    minitest (5.8.1)
     rake (10.4.2)
-    scrypt (2.0.0)
+    scrypt (2.0.2)
       ffi-compiler (>= 0.0.2)
       rake
 
@@ -31,4 +31,4 @@ DEPENDENCIES
   scrypt
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -322,7 +322,8 @@ module Bitcoin
 
     def bitcoin_signed_message_hash(message)
       # TODO: this will fail horribly on messages with len > 255. It's a cheap implementation of Bitcoin's CDataStream.
-      data = "\x18Bitcoin Signed Message:\n" + [message.bytesize].pack("C") + message
+      raise ArgumentError.new("message.length > 255!") if message.length > 255
+      data = "\x18Bitcoin Signed Message:\n" + [message.bytesize].pack("C") + message.dup.force_encoding("binary")
       Digest::SHA256.digest(Digest::SHA256.digest(data))
     end
 


### PR DESCRIPTION
For consistency reasons, the message entering Bitcoin.sign_message should always be treated as binary.

This change also makes Bitcoin.sign_message raise if a message was passed in with more than 255 characters.
