### PR TITLE
Fixing incorrect comment

### DIFF
--- a/lib/bitcoin/builder.rb
+++ b/lib/bitcoin/builder.rb
@@ -438,7 +438,7 @@ module Bitcoin
     #    o.script {|s| s.recipient address }
     #  end
     #
-    #  t.output {|o| o.to "deadbeef", OP_RETURN }
+    #  t.output {|o| o.to "deadbeef", :op_return }
     class TxOutBuilder
       attr_reader :txout
 


### PR DESCRIPTION
`TxOutBuilder` expects a symbol (i.e. `:op_return`), not the constant (i.e. `OP_RETURN`).
