### PR TITLE
Update ffi/openssl.rb to load openssl 1.0 if available

### DIFF
--- a/lib/bitcoin/ffi/openssl.rb
+++ b/lib/bitcoin/ffi/openssl.rb
@@ -11,7 +11,7 @@ module OpenSSL_EC
   if FFI::Platform.windows?
     ffi_lib 'libeay32', 'ssleay32'
   else
-    ffi_lib 'ssl'
+    ffi_lib [ 'libssl.so.1.0.0', 'ssl' ]
   end
 
   NID_secp256k1 = 714


### PR DESCRIPTION
This updates the `ffi_lib` call to specify some alternative libraries which will
prioritize loading openssl 1.0. This fixes an issue on hosts which have openssl
1.1 and 1.0 and would encounter an error for the `SSL_library_init` function not
being found.

Fixes #205