### PR TITLE
Support ruby-2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: ruby
 rvm:
   - 2.2.0
   - 2.3.2
+  - 2.4.1

--- a/lib/bitcoin/key.rb
+++ b/lib/bitcoin/key.rb
@@ -69,13 +69,15 @@ module Bitcoin
     end
 
     def pub_compressed
-      @key.public_key.group.point_conversion_form = :compressed
-      @key.public_key.to_hex.rjust(66, '0')
+      public_key = @key.public_key
+      public_key.group.point_conversion_form = :compressed
+      public_key.to_hex.rjust(66, '0')
     end
 
     def pub_uncompressed
-      @key.public_key.group.point_conversion_form = :uncompressed
-      @key.public_key.to_hex.rjust(130, '0')
+      public_key = @key.public_key
+      public_key.group.point_conversion_form = :uncompressed
+      public_key.to_hex.rjust(130, '0')
     end
 
     def compressed


### PR DESCRIPTION
`OpenSSL::PKey::EC` in openssl of Ruby 2.4 contains bugs that are not in before 2.3.

If set public key using `OpenSSL::PKey::EC#public_key=` then set EC group encoding to :compressed, and get the public key again using `OpenSSL::PKey::EC#public_key`, so public key encoding is :uncompressed.

```ruby
key = OpenSSL::PKey::EC.new("secp256k1")
pub_key = '03cdd34ec0a05d91c026fe8cb74434923075d3acc20f3f673fb855c8f2c04ca522' # compressed pubkey

# success case
point = OpenSSL::PKey::EC::Point.new(key.group, OpenSSL::BN.new(pub_key, 16))
point.group.point_conversion_form = :compressed

# with 2.3 and 2.4, following result is :compressed
puts point.group.point_conversion_form

# error case
key.public_key = OpenSSL::PKey::EC::Point.new(key.group, OpenSSL::BN.new(pub_key, 16))
key.public_key.group.point_conversion_form = :compressed

# with 2.4, following results is :uncompressed
puts key.public_key.group.point_conversion_form
```
https://bugs.ruby-lang.org/issues/13100

`Bitcoin::Key#pub_compressed` is affected by this and will not work properly with Ruby 2.4.
Therefore, I added work-around patch to work with Ruby 2.4.