### PR TITLE
Add invalid private key range check

### DIFF
--- a/lib/bitcoin/key.rb
+++ b/lib/bitcoin/key.rb
@@ -7,6 +7,10 @@ module Bitcoin
 
     attr_reader :key
 
+    MIN_PRIV_KEy_MOD_ORDER = 0x01
+    # Order of secp256k1's generator minus 1.
+    MAX_PRIV_KEY_MOD_ORDER = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140
+
     # Generate a new keypair.
     #  Bitcoin::Key.generate
     def self.generate(opts={compressed: true})
@@ -255,6 +259,8 @@ module Bitcoin
 
     # Set +priv+ as the new private key (converting from hex).
     def set_priv(priv)
+      value = priv.to_i(16)
+      raise 'private key is not on curve' unless MIN_PRIV_KEy_MOD_ORDER <= value && value <= MAX_PRIV_KEY_MOD_ORDER
       @key.private_key = OpenSSL::BN.from_hex(priv)
     end
 

--- a/spec/bitcoin/key_spec.rb
+++ b/spec/bitcoin/key_spec.rb
@@ -252,6 +252,13 @@ describe "Bitcoin::Key" do
     k.to_base58.should == "5JBAonQ4iGKFJxENExZghDtAS6YB8BsCw5mwpHSvZvP3Q2UxmT1"
   end
 
+  it "should raise error for private key out of range." do
+    proc{Bitcoin::Key.new('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141')}.should.raise(Exception)
+    proc{Bitcoin::Key.new('00')}.should.raise(Exception)
+    proc{Bitcoin::Key.new('FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140')}.should.not.raise(Exception)
+    proc{Bitcoin::Key.new('01')}.should.not.raise(Exception)
+  end
+
 end
 
 begin


### PR DESCRIPTION
A valid ECDSA private key range from `0x1P` to `0xFFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFE BAAE DCE6 AF48 A03B BFD2 5E8C D036` 

Currently, `Bitcoin::Key` accepts private keys outside of this range.

So, when a private key outside the range is specified, it is modified to raise an exception.
