### PR TITLE
[Fix] Empty Transaction Parsing

### DIFF
--- a/lib/bitcoin/protocol/tx.rb
+++ b/lib/bitcoin/protocol/tx.rb
@@ -88,8 +88,15 @@ module Bitcoin
         if in_size.zero?
           @marker = 0
           @flag = buf.read(1).unpack('c').first
-          in_size = Protocol.unpack_var_int_from_io(buf)
-          witness = true
+
+          # marker must be zero and flag must be non-zero to be valid segwit
+          if @marker == 0 && @flag != 0
+            in_size = Protocol.unpack_var_int_from_io(buf)
+            witness = true
+          else
+            # Undo the last read in case this isn't a segwit transaction
+            buf.seek(buf.pos - 1)
+          end
         end
 
         @in = []

--- a/spec/bitcoin/protocol/tx_spec.rb
+++ b/spec/bitcoin/protocol/tx_spec.rb
@@ -30,6 +30,9 @@ describe 'Tx' do
     proc{
       Tx.new( @payload[0][0..20] )
     }.should.raise Exception
+
+    # Deserializing a new, empty transaction works
+    Tx.new(Tx.new.to_payload)
   end
 
   it '#parse_data' do


### PR DESCRIPTION
Currently, transaction processing in the empty transaction case causes an exception `TypeError: no
implicit conversion of nil into Integer`. This error occurs because segwit enabled transaction
parsing does not correctly handle the case where the transaction has no inputs but is not a valid
segwit transaction.

This fix provides a test to reproduce the error case and corrects the behavior in the above edge
case by checking that the marker and flag values conform to those required by the segwit
standard. In the case where they do not, it backs out the previous reads enabling the transaction to
parse correctly.