### PR TITLE
Support TxOut when verifying an input sig

### DIFF
--- a/lib/bitcoin/script.rb
+++ b/lib/bitcoin/script.rb
@@ -1435,8 +1435,10 @@ class Bitcoin::Script
   def sighash_subscript(drop_sigs, opts = {})
     if opts[:fork_id]
       drop_sigs.reject! do |signature|
-        _, hash_type = parse_sig(signature)
-        (hash_type&SIGHASH_TYPE[:forkid]) != 0
+        if signature && signature.size > 0
+          _, hash_type = parse_sig(signature)
+          (hash_type&SIGHASH_TYPE[:forkid]) != 0
+        end
       end
     end
 

--- a/spec/bitcoin/protocol/tx_spec.rb
+++ b/spec/bitcoin/protocol/tx_spec.rb
@@ -316,6 +316,9 @@ describe 'Tx' do
 
     tx.verify_input_signature(0, outpoint_tx).should == true
 
+    # Only one test where we provide the TxOut is needed since when providing
+    # the full outpoint_tx the verification logic doesn't change.
+    tx.verify_input_signature(0, outpoint_tx.out[0]).should == true
 
     tx = Tx.from_json( fixtures_file('rawtx-c99c49da4c38af669dea436d3e73780dfdb6c1ecf9958baa52960e8baee30e73.json') )
     tx.hash.should == 'c99c49da4c38af669dea436d3e73780dfdb6c1ecf9958baa52960e8baee30e73'


### PR DESCRIPTION
**Support TxOut when verifying an input sig**

This adds support providing a TxOut when verifying an input signature.

This is useful in one of our use cases where we need to sign
a transaction but only have enough information to craft a TxOut, not
a full Tx. Since that provides the same information as the Tx does, this
option now supports that.

Because the duck-typing was used in a few places I extracted it out to
a method than can be used in a multiple places.

**Verify sig length before parsing**

When verifying an incomplete multisig transaction, we end up with a list
of drop_sigs like so:

```
["", "0E\x02!\x00\xF6#\x00\xC1\xA7\xB5l[\xD4y}\x93\xDEV\xD5\xAB\x83TT\x0FYr?J\xB3\x88\xD0=$\xD3\x127\x02 6\xAB\xED7+5V\xE3\xBB\xA0UK\xB9}\x8F\xC8Pf\xC5\x84zo\x12?\xB6\x1D]Sr\x9A\x83\xE5\x01"]
```

This resolves a bug where we attempted to parse it which would raise in
the `parse_sig` method. We now reject the sig unless it's present.