### PR TITLE
Update supported ruby versions

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -22,11 +22,9 @@ Some of the main features are:
 
 == Compatible with...
 
-* ruby 1.9.3
-* ruby 2.0.0
-* ruby 2.1.2
 * ruby 2.2.0
-* ruby 2.2.2
+* ruby 2.3.2
+* ruby 2.4.1
 
 == Installation
 


### PR DESCRIPTION
As seen here it's still passing: https://travis-ci.org/Intrepidd/bitcoin-ruby/builds/317338442

However on your travis page it doesn't show up ? https://travis-ci.org/lian/bitcoin-ruby I think you have to re-enable your travis build.

I'll probably submit another PR to test against the latest ruby versions