### PR TITLE
Autoload ExtPubKey for HD wallet address generation

### DIFF
--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -16,6 +16,7 @@ module Bitcoin
   autoload :Logger,     'bitcoin/logger'
   autoload :Key,        'bitcoin/key'
   autoload :ExtKey,     'bitcoin/ext_key'
+  autoload :ExtPubKey,     'bitcoin/ext_key'
   autoload :Builder,    'bitcoin/builder'
   autoload :BloomFilter,'bitcoin/bloom_filter'
 


### PR DESCRIPTION
Allow ExtPubKey to be accessible to gem users so they can generate addresses from extended public keys (esp for hierarchical deterministic wallets)