### PR TITLE
Recognize legacy Litecoin P2SH addresses as valid.

### DIFF
--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -99,10 +99,16 @@ module Bitcoin
 
       hex = decode_base58(address) rescue nil
       if hex && hex.bytesize == 50 && address_checksum?(address)
+        # Litecoin updates the P2SH version byte, and this method should recognize both.
+        p2sh_versions = [p2sh_version]
+        if Bitcoin.network[:legacy_p2sh_versions]
+          p2sh_versions += Bitcoin.network[:legacy_p2sh_versions]
+        end
+
         case hex[0...2]
         when address_version
           return :hash160
-        when p2sh_version
+        when *p2sh_versions
           return :p2sh
         end
       end
@@ -727,6 +733,7 @@ module Bitcoin
       message_magic: "Litecoin Signed Message:\n",
       address_version: "30",
       p2sh_version: "32",
+      legacy_p2sh_versions: ["05"],
       privkey_version: "b0",
       bech32_hrp: "ltc",
       extended_privkey_version: "019d9cfe",
@@ -778,6 +785,7 @@ module Bitcoin
       magic_head: "\xfd\xd2\xc8\xf1",
       address_version: "6f",
       p2sh_version: "3a",
+      legacy_p2sh_versions: nil,
       privkey_version: "ef",
       bech32_hrp: "tltc",
       extended_privkey_version: "0436ef7d",

--- a/spec/bitcoin/bitcoin_spec.rb
+++ b/spec/bitcoin/bitcoin_spec.rb
@@ -192,6 +192,14 @@ describe 'Bitcoin Address/Hash160/PubKey' do
     Bitcoin.address_type("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4").should == :witness_v0_keyhash
     Bitcoin.address_type("bc1qw508d6qejxtdg4y5r3zarvayr0c5xw7kv8f3t4").should == nil
     Bitcoin.address_type("bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3").should == :witness_v0_scripthash
+
+    # address_type recognizes Litecoin addresses encoded with the legacy P2SH version byte
+    Bitcoin.network = :litecoin
+    Bitcoin.address_type("3CkxTG25waxsmd13FFgRChPuGYba3ar36B").should == :p2sh
+    Bitcoin.address_type("MJy6m9S3thpJa8GwM8fm2LeJbFC22w18Vx").should == :p2sh
+    Bitcoin.address_type("2MyLngQnhzjzatKsB7XfHYoP9e2XUXSiBMM").should == nil
+
+    Bitcoin.network = :bitcoin
   end
 
   it 'Bitcoin#checksum' do


### PR DESCRIPTION
Commit 6413cd1bd0aff4521b4252cdf8973b10102cf003 caused an issue where bitcoin-ruby does not detect legacy Litecoin addesses as valid. Even though the version byte is upgraded, this library should recognize both for backwards-compatibility.