### PR TITLE
Rescue decode_segwit_address and return nil instead

### DIFF
--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -83,7 +83,7 @@ module Bitcoin
 
     # get type of given +address+.
     def address_type(address)
-      segwit_decoded = decode_segwit_address(address)
+      segwit_decoded = decode_segwit_address(address) rescue nil
       if segwit_decoded
         witness_version, witness_program_hex = segwit_decoded
         witness_program = [witness_program_hex].pack("H*")


### PR DESCRIPTION
Commit f62bd3998cb8805373739f3fa771d08e4959798e introduced the `decode_segwit_address` as a step in determining the `valid_address?` of an address.  Previously the contract was for `decode_base58` to rescue all errors and return nil, but that wasn't maintained for segwit addresses.  This simply keeps the interface the same.