### PR TITLE
Fix get_addresses to return array of addresses

### DIFF
--- a/lib/bitcoin/script.rb
+++ b/lib/bitcoin/script.rb
@@ -734,7 +734,7 @@ class Bitcoin::Script
 
     if is_witness_v0_keyhash? || is_witness_v0_scripthash?
       program_hex = chunks[1].unpack("H*").first
-      return Bitcoin.encode_segwit_address(0, program_hex)
+      return [Bitcoin.encode_segwit_address(0, program_hex)]
     end
 
     []

--- a/spec/bitcoin/script/script_spec.rb
+++ b/spec/bitcoin/script/script_spec.rb
@@ -207,6 +207,8 @@ describe 'Bitcoin::Script' do
       Script.new(SCRIPT[3]).get_addresses
         .should == ["1JiaVc3N3U3CwwcLtzNX1Q4eYfeYxVjtuj",
         "19Fm2gY7qDTXriNTEhFY2wjxbHna3Gvenk", "1B6k6g1d2L975i7beAbiBRxfBWhxomPxvy"]
+      Script.new(SCRIPT[7]).get_addresses.
+        should == ["bc1qrcs9z5wfpstyw5mr6ydhhrprtnmv0454y6laym"]
     end
 
     it "should get op_return data" do


### PR DESCRIPTION
For all the script types, get_addresses returns an array, except for the
case where it `is_witness_v0_keyhash?` or it
`is_witness_v0_scripthash?`.  This fixes the contract so this won't
error out when iterating over addresses, and adds a spec to prevent
regressions.