### PR TITLE
TxBuilder doesn't work properly for segwit tx

### DIFF
--- a/lib/bitcoin/builder.rb
+++ b/lib/bitcoin/builder.rb
@@ -299,6 +299,9 @@ module Bitcoin
             if script.is_witness_v0_keyhash? # for p2wpkh
               @tx.in[i].script_witness.stack << inc.sign(@sig_hash) + [Script::SIGHASH_TYPE[:all]].pack("C")
               @tx.in[i].script_witness.stack << inc.key.pub.htb
+
+              redeem_script = inc.instance_eval { @redeem_script }
+              @tx.in[i].script_sig = Bitcoin::Script.pack_pushdata(redeem_script) if redeem_script
             else
               @tx.in[i].script_sig = get_script_sig(inc, hash_type)
             end

--- a/lib/bitcoin/builder.rb
+++ b/lib/bitcoin/builder.rb
@@ -303,8 +303,13 @@ module Bitcoin
               @tx.in[i].script_sig = get_script_sig(inc, hash_type)
             end
             # double-check that the script_sig is valid to spend the given prev_script
-            if @prev_script && !inc.prev_out_forkid && !@tx.verify_input_signature(i, @prev_script)
-              raise "Signature error"
+            if @prev_script && !inc.prev_out_forkid
+              verified = if script.is_witness_v0_keyhash?
+                @tx.verify_witness_input_signature(i, @prev_script, inc.value)
+              else
+                @tx.verify_input_signature(i, @prev_script)
+              end
+              raise "Signature error" unless verified
             end
           elsif inc.has_multiple_keys?
             raise "Keys missing for multisig signing"

--- a/spec/bitcoin/builder_spec.rb
+++ b/spec/bitcoin/builder_spec.rb
@@ -102,6 +102,7 @@ describe "Bitcoin::Builder" do
       end
     end
     tx.verify_witness_input_signature(0, script_pubkey, 600000000).should == true
+    tx.in[0].script_sig.should == ''
   end
 
   it "should failure to build tx with p2wpkh signatures due to inconsistency of key" do
@@ -115,6 +116,21 @@ describe "Bitcoin::Builder" do
         end
       end
     end.should.raise
+  end
+
+  it "should build p2sh transaction with p2wpkh signatures" do
+    key = Bitcoin::Key.new('619c335025c7f4012e556c2a58b2506e30b8511b53ade95ea316fd8c3286feb9')
+    witness_prog = '00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1'.htb
+    script_pubkey = Bitcoin::Script.to_p2sh_script('bdbb096c26dd64dca06d0fbe8bb5e990ac3cdb42')
+    tx = build_tx do |t|
+      t.input do |i|
+        i.prev_out SecureRandom.hex(32), 0, script_pubkey, 600000000
+        i.redeem_script witness_prog
+        i.signature_key key
+      end
+    end
+    tx.verify_witness_input_signature(0, witness_prog, 600000000).should == true
+    tx.in[0].script_sig.should == Bitcoin::Script.pack_pushdata(witness_prog)
   end
 
   it "should allow txin.prev_out as tx or hash" do

--- a/spec/bitcoin/builder_spec.rb
+++ b/spec/bitcoin/builder_spec.rb
@@ -104,6 +104,19 @@ describe "Bitcoin::Builder" do
     tx.verify_witness_input_signature(0, script_pubkey, 600000000).should == true
   end
 
+  it "should failure to build tx with p2wpkh signatures due to inconsistency of key" do
+    key = Bitcoin::Key.new('619c335025c7f4012e556c2a58b2506e30b8511b53ade95ea316fd8c3286feb9')
+    script_pubkey = '0014deadbeafdeadbeafdeadbeafdeadbeafdeadbeaf'.htb
+    proc do
+      build_tx do |t|
+        t.input do |i|
+          i.prev_out '8ac60eb9575db5b2d987e29f301b5b819ea83a5c6579d282d189cc04b8e151ef', 1, script_pubkey, 600000000
+          i.signature_key key
+        end
+      end
+    end.should.raise
+  end
+
   it "should allow txin.prev_out as tx or hash" do
     prev_tx = @block.tx[0]
     tx1 = build_tx do |t|


### PR DESCRIPTION
This PR fixes `TxBuilder` to:
- verify signature by `verify_witness_input_signature` when the pubkey script is witness program
- build P2SH-nested segwit tx properly 