### PR TITLE
Improve behavior of `Bitcoin::Protocol::Txout#to_hash with_address:` option

### DIFF
--- a/lib/bitcoin/protocol/txout.rb
+++ b/lib/bitcoin/protocol/txout.rb
@@ -66,7 +66,10 @@ module Bitcoin
       def to_hash(options = {})
         h = { 'value' => "%.8f" % (@value / 100000000.0),
           'scriptPubKey' => parsed_script.to_string }
-        h["address"] = parsed_script.get_address  if parsed_script.is_hash160? && options[:with_address]
+        if options[:with_address]
+          addrs = parsed_script.get_addresses
+          h['address'] = addrs.first if addrs.size == 1
+        end
         h
       end
 


### PR DESCRIPTION
Currently, `Bitcoin::Protocol::Txout#to_hash with_address:` option outputs address only if destination is p2pkh.

This pr fixes it so that if result address is unique, then the address is returned.