### PR TITLE
Add rake task to build libsecp256k1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,7 @@ rvm:
   - 2.2.9
   - 2.3.6
   - 2.4.3
-  - 2.5.0
+  - 2.5.1
+script:
+  - bundle exec rake build_libsecp256k1
+  - bundle exec rake bacon


### PR DESCRIPTION
Currently, some tests are not run in CI because they require libsecp256k1. In addition, it can be
unclear to consumers of the library how they need to build libsecp256k1 so that it can be used with
bitcoin-ruby.

This change adds a new rake task `build_libsecp256k1` that will download and build the library from
the [GitHub repository](https://github.com/bitcoin-core/secp256k1). This ability is then leveraged
to warn users when they run tests without the library that they are skipping tests. In addition, the
`SECP256K1_LIB_PATH` environment variable is now automatically populated if the library has been
built.

The TravisCI build is then updated so that it builds this dependencies and runs the previously
skipped tests.