### PR TITLE
Clean up Gemfile and gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,15 @@
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in bitcoin-ruby.gemspec
 gemspec
 
-group :development do
-  gem 'eventmachine'
-  gem 'ffi'
-  gem 'scrypt'
-  gem 'minitest'
+group :test do
+  gem 'rake', '~> 12.3.1'
+  gem 'bacon', '~> 1.2.0'
+  gem 'simplecov', '~> 0.16.1'
+  gem 'minitest', '~> 5.11.3'
+end
 
-  gem "rake", ">= 0.8.0"
-  gem 'bacon', '>= 1.2.0'
-  #gem 'simplecov', require: false
+group :development do
+  gem 'pry', '~> 0.11.3'
+  gem 'pry-byebug', '~> 3.6.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,32 +2,51 @@ PATH
   remote: .
   specs:
     bitcoin-ruby (0.0.18)
+      eventmachine
+      ffi
+      scrypt
 
 GEM
   remote: https://rubygems.org/
   specs:
     bacon (1.2.0)
-    eventmachine (1.2.3)
-    ffi (1.9.18)
+    byebug (10.0.2)
+    coderay (1.1.2)
+    docile (1.3.1)
+    eventmachine (1.2.7)
+    ffi (1.9.25)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    minitest (5.10.2)
-    rake (12.0.0)
+    json (2.1.0)
+    method_source (0.9.0)
+    minitest (5.11.3)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
+    rake (12.3.1)
     scrypt (3.0.5)
       ffi-compiler (>= 1.0, < 2.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bacon (>= 1.2.0)
+  bacon (~> 1.2.0)
   bitcoin-ruby!
-  eventmachine
-  ffi
-  minitest
-  rake (>= 0.8.0)
-  scrypt
+  minitest (~> 5.11.3)
+  pry (~> 0.11.3)
+  pry-byebug (~> 3.6.0)
+  rake (~> 12.3.1)
+  simplecov (~> 0.16.1)
 
 BUNDLED WITH
-   1.14.6
+   1.16.2

--- a/bitcoin-ruby.gemspec
+++ b/bitcoin-ruby.gemspec
@@ -19,6 +19,9 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.required_rubygems_version = ">= 1.3.6"
-  #s.add_development_dependency "bacon"
+  s.required_rubygems_version = ">= 2.6.13"
+
+  s.add_runtime_dependency 'ffi'
+  s.add_runtime_dependency 'scrypt' # required by Litecoin
+  s.add_runtime_dependency 'eventmachine' # required for connection code
 end

--- a/spec/bitcoin/protocol/version_spec.rb
+++ b/spec/bitcoin/protocol/version_spec.rb
@@ -11,6 +11,10 @@ describe 'Bitcoin::Protocol::Parser (version)' do
     end
   end
 
+  before do
+    Bitcoin.network = :bitcoin
+  end
+
   it 'parses version packets' do
     pkt = Bitcoin::Protocol.pkt("version",
       ["60ea00000100000000000000b3c1424f00000000010000000000000000000000000000000000ffff7f000001e1ca010000000000000000000000000000000000ffff7f000001479d9525d0c7b30688ae122f626974636f696e2d71743a302e362e302f82b60000"].pack("H*"))


### PR DESCRIPTION
This change involved cleaning up the Gemfile and gemspec to help ensure that
all dependencies required to run bitcoin-ruby and any of the coins it supports
are all present. Namely, the following things were done:

* Add all required runtime dependencies to `bitcoin-ruby.gemspec`.
* Reorganize the `Gemfile` to contain separated test and development dependencies.
* Fix broken `coverage` rake task by fixing cross-test state that prevented all tests from being run together.
* Update all out-of-date dependencies required for test and development.

Closes #257