### PR TITLE
Lint the protocol directory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,11 +2,8 @@ AllCops:
   Exclude:
     - 'Gemfile'
 
-Metrics/LineLength:
+Metrics/AbcSize:
   Max: 100
-
-Metrics/MethodLength:
-  Max: 80
 
 Metrics/BlockLength:
   Max: 50
@@ -14,6 +11,33 @@ Metrics/BlockLength:
     - 'spec/**/*'
     - 'db/migrations/**/*'
     - 'tasks/**/*'
+
+Metrics/ClassLength:
+  Max: 500
+
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+Metrics/LineLength:
+  Max: 100
+
+Metrics/MethodLength:
+  Max: 80
+
+Metrics/PerceivedComplexity:
+  Max: 10
+
+Naming/UncommunicativeMethodParamName:
+  Enabled: False
+
+Style/FrozenStringLiteralComment:
+  Enabled: False
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/SafeNavigation:
+  Enabled: false
 
 Style/UnpackFirst:
   Enabled: false

--- a/lib/bitcoin/protocol/address.rb
+++ b/lib/bitcoin/protocol/address.rb
@@ -2,9 +2,7 @@
 
 module Bitcoin
   module Protocol
-
-    class Addr < Struct.new(:time, :service, :ip, :port)
-
+    Addr = Struct.new(:time, :service, :ip, :port) do
       # # IP Address / Port
       # attr_reader :ip, :port
 
@@ -17,22 +15,25 @@ module Bitcoin
       # create addr from raw binary +data+
       def initialize(data = nil)
         if data
-          self[:time], self[:service], self[:ip], self[:port] = data.unpack("VQx12a4n")
-          self[:ip] = ip.unpack("C*").join(".")
+          unpacked = data.unpack('VQx12a4n')
+          self[:time], self[:service], self[:ip], self[:port] = unpacked
+          self[:ip] = ip.unpack('C*').join('.')
         else
-          self[:time], self[:service] = Time.now.to_i, 1
-          self[:ip], self[:port] = "127.0.0.1", Bitcoin.network[:default_port]
+          self[:time] = Time.now.to_i
+          self[:service] = 1
+          self[:ip] = '127.0.0.1'
+          self[:port] = Bitcoin.network[:default_port]
         end
       end
 
       # is this address alive?
       def alive?
-        (Time.now.tv_sec-7200) <= self[:time]
+        (Time.now.tv_sec - 7200) <= self[:time]
       end
 
       def to_payload
-        ip = self[:ip].split(".").map(&:to_i)
-        [ time, service, ("\x00"*10)+"\xff\xff", *ip, port ].pack("VQa12C4n")
+        ip = self[:ip].split('.').map(&:to_i)
+        [time, service, ("\x00" * 10) + "\xff\xff", *ip, port].pack('VQa12C4n')
       end
 
       def string
@@ -40,11 +41,12 @@ module Bitcoin
       end
 
       def self.pkt(*addrs)
-        addrs = addrs.select{|i| i.is_a?(Bitcoin::Protocol::Addr) && i.ip =~ /^\d+\.\d+\.\d+\.\d+$/ }
+        addrs = addrs.select do |i|
+          i.is_a?(Bitcoin::Protocol::Addr) && i.ip =~ /^\d+\.\d+\.\d+\.\d+$/
+        end
         length = Bitcoin::Protocol.pack_var_int(addrs.size)
-        Bitcoin::Protocol.pkt("addr", length + addrs.map(&:to_payload).join)
+        Bitcoin::Protocol.pkt('addr', length + addrs.map(&:to_payload).join)
       end
     end
-
   end
 end

--- a/lib/bitcoin/protocol/alert.rb
+++ b/lib/bitcoin/protocol/alert.rb
@@ -1,46 +1,51 @@
 # encoding: ascii-8bit
 
 module Bitcoin
-module Protocol
+  module Protocol
+    Alert = Struct.new(
+      :version, :relay_until, :expiration, :id, :cancel, :set_cancel,
+      :min_ver, :max_ver, :set_sub_ver, :priority, :comment, :status_bar, :reserved
+    ) do
 
-  class Alert < Struct.new(:version, :relay_until, :expiration, :id, :cancel, :set_cancel,
-                           :min_ver, :max_ver, :set_sub_ver, :priority, :comment, :status_bar, :reserved)
+      attr_accessor :payload, :signature
 
-    attr_accessor :payload, :signature
+      def initialize(values, alert_payload = nil, alert_signature = nil)
+        @payload = alert_payload
+        @signature = alert_signature
+        super(*values)
+      end
 
-    def initialize(values, alert_payload=nil, alert_signature=nil)
-      @payload, @signature = alert_payload, alert_signature
-      super(*values)
-    end
+      def valid_signature?
+        return false unless @payload && @signature
+        hash = Digest::SHA256.digest(Digest::SHA256.digest(@payload))
+        Bitcoin.network[:alert_pubkeys].any? do |public_key|
+          Bitcoin.verify_signature(hash, @signature, public_key)
+        end
+      end
 
-    def valid_signature?
-      return false unless @payload && @signature
-      hash = Digest::SHA256.digest(Digest::SHA256.digest(@payload))
-      Bitcoin.network[:alert_pubkeys].any?{|public_key| Bitcoin.verify_signature(hash, @signature, public_key) }
-    end
+      def self.parse(payload)
+        count, payload = Bitcoin::Protocol.unpack_var_int(payload)
+        alert_payload, payload = payload.unpack("a#{count}a*")
+        count, payload = Bitcoin::Protocol.unpack_var_int(payload)
+        alert_signature, = payload.unpack("a#{count}a*")
 
+        version, relay_until, expiration, id, cancel, payload = alert_payload.unpack('VQQVVa*')
 
-    def self.parse(payload)
-      count,             payload = Bitcoin::Protocol.unpack_var_int(payload)
-      alert_payload,     payload = payload.unpack("a#{count}a*")
-      count,             payload = Bitcoin::Protocol.unpack_var_int(payload)
-      alert_signature,   payload = payload.unpack("a#{count}a*")
+        set_cancel, payload = Bitcoin::Protocol.unpack_var_int_array(payload)
+        min_ver, max_ver, payload = payload.unpack('VVa*')
+        set_sub_ver, payload = Bitcoin::Protocol.unpack_var_string_array(payload)
+        priority, payload = payload.unpack('Va*')
+        comment, payload = Bitcoin::Protocol.unpack_var_string(payload)
+        status_bar, payload = Bitcoin::Protocol.unpack_var_string(payload)
+        reserved, = Bitcoin::Protocol.unpack_var_string(payload)
 
-      version, relay_until, expiration, id, cancel, payload = alert_payload.unpack("VQQVVa*")
+        values = [
+          version, relay_until, expiration, id, cancel, set_cancel, min_ver,
+          max_ver, set_sub_ver, priority, comment, status_bar, reserved
+        ]
 
-      set_cancel,        payload = Bitcoin::Protocol.unpack_var_int_array(payload)
-      min_ver, max_ver,  payload = payload.unpack("VVa*")
-      set_sub_ver,       payload = Bitcoin::Protocol.unpack_var_string_array(payload)
-      priority,          payload = payload.unpack("Va*")
-      comment,           payload = Bitcoin::Protocol.unpack_var_string(payload)
-      status_bar,        payload = Bitcoin::Protocol.unpack_var_string(payload)
-      reserved,          payload = Bitcoin::Protocol.unpack_var_string(payload)
-
-      values = [ version, relay_until, expiration, id, cancel, set_cancel, min_ver, max_ver, set_sub_ver, priority, comment, status_bar, reserved ]
-
-      new(values, alert_payload, alert_signature)
+        new(values, alert_payload, alert_signature)
+      end
     end
   end
-
-end
 end

--- a/lib/bitcoin/protocol/block.rb
+++ b/lib/bitcoin/protocol/block.rb
@@ -2,9 +2,8 @@
 
 module Bitcoin
   module Protocol
-
+    # https://en.bitcoin.it/wiki/Protocol_documentation#block
     class Block
-
       BLOCK_VERSION_DEFAULT     = (1 << 0)
       BLOCK_VERSION_AUXPOW      = (1 << 8)
       BLOCK_VERSION_CHAIN_START = (1 << 16)
@@ -15,8 +14,10 @@ module Bitcoin
 
       # previous block hash
       attr_accessor :prev_block_hash
-      alias :prev_block :prev_block_hash
-      def prev_block=(hash); @prev_block_hash = hash; end
+      alias prev_block prev_block_hash
+      def prev_block=(hash)
+        @prev_block_hash = hash
+      end
 
       # transactions (Array of Tx)
       attr_accessor :tx
@@ -44,7 +45,7 @@ module Bitcoin
 
       attr_reader :partial_merkle_tree
 
-      alias :transactions :tx
+      alias transactions tx
 
       # compare to another block
       def ==(other)
@@ -52,15 +53,15 @@ module Bitcoin
       end
 
       def binary_hash
-        [@hash].pack("H*")
+        [@hash].pack('H*')
       end
 
       def prev_block_hex
-        @prev_block_hex ||= @prev_block_hash.reverse.unpack("H*")[0]
+        @prev_block_hex ||= @prev_block_hash.reverse.unpack('H*')[0]
       end
 
       # create block from raw binary +data+
-      def initialize(data=nil)
+      def initialize(data = nil)
         @tx = []
         @payload = nil
         parse_data_from_io(data) if data
@@ -73,68 +74,74 @@ module Bitcoin
       end
 
       # parse raw binary data
-      def parse_data_from_io(buf, header_only=false)
+      def parse_data_from_io(buf, header_only = false)
         buf = buf.is_a?(String) ? StringIO.new(buf) : buf
-        @ver, @prev_block_hash, @mrkl_root, @time, @bits, @nonce = buf.read(80).unpack("Va32a32VVV")
+        @ver, @prev_block_hash, @mrkl_root, @time, @bits, @nonce = buf.read(80).unpack('Va32a32VVV')
         recalc_block_hash
 
-        if Bitcoin.network[:auxpow_chain_id] != nil && (@ver & BLOCK_VERSION_AUXPOW) > 0
+        if !Bitcoin.network[:auxpow_chain_id].nil? && (@ver & BLOCK_VERSION_AUXPOW) > 0
           @aux_pow = AuxPow.new(nil)
           @aux_pow.parse_data_from_io(buf)
         end
 
         return buf if buf.eof?
 
-        if header_only == :filtered
-          @tx_count = buf.read(4).unpack("V")[0]
-
-          nhashes = Protocol.unpack_var_int_from_io(buf)
-          hashes = []
-          nhashes.times do
-            hashes << buf.read(256 / 8)
-          end
-
-          nflags = Protocol.unpack_var_int_from_io(buf)
-          flags = buf.read(nflags)
-
-          @partial_merkle_tree = PartialMerkleTree.new(@tx_count, hashes, flags)
-          @partial_merkle_tree.set_value
-
-          return buf
-        end
+        return parse_filtered_header(buf) if header_only == :filtered
 
         tx_size = Protocol.unpack_var_int_from_io(buf)
         @tx_count = tx_size
         return buf if header_only
 
-        tx_size.times{
+        tx_size.times do
           break if payload == true
           return buf if buf.eof?
 
           t = Tx.new(nil)
           t.parse_data_from_io(buf)
           @tx << t
-        }
+        end
 
         @payload = to_payload
         buf
       end
 
+      def parse_filtered_header(buf)
+        @tx_count = buf.read(4).unpack('V')[0]
+
+        nhashes = Protocol.unpack_var_int_from_io(buf)
+        hashes = []
+        nhashes.times do
+          hashes << buf.read(256 / 8)
+        end
+
+        nflags = Protocol.unpack_var_int_from_io(buf)
+        flags = buf.read(nflags)
+
+        @partial_merkle_tree = PartialMerkleTree.new(@tx_count, hashes, flags)
+        @partial_merkle_tree.assign_value
+
+        buf
+      end
+
       # recalculate the block hash
       def recalc_block_hash
-        @hash = Bitcoin.block_hash(@prev_block_hash.reverse_hth, @mrkl_root.reverse_hth, @time, @bits, @nonce, @ver)
+        @hash = Bitcoin.block_hash(
+          @prev_block_hash.reverse_hth, @mrkl_root.reverse_hth, @time, @bits, @nonce, @ver
+        )
       end
 
       def recalc_block_scrypt_hash
-        @scrypt_hash = Bitcoin.block_scrypt_hash(@prev_block_hash.reverse_hth, @mrkl_root.reverse_hth, @time, @bits, @nonce, @ver)
+        @scrypt_hash = Bitcoin.block_scrypt_hash(
+          @prev_block_hash.reverse_hth, @mrkl_root.reverse_hth, @time, @bits, @nonce, @ver
+        )
       end
 
       def recalc_mrkl_root
         @mrkl_root = if partial_merkle_tree
-          partial_merkle_tree.root.value.htb_reverse
-        else
-          Bitcoin.hash_mrkl_tree( @tx.map(&:hash) ).last.htb_reverse
-        end
+                       partial_merkle_tree.root.value.htb_reverse
+                     else
+                       Bitcoin.hash_mrkl_tree(@tx.map(&:hash)).last.htb_reverse
+                     end
       end
 
       # verify mrkl tree
@@ -142,7 +149,7 @@ module Bitcoin
         if partial_merkle_tree
           partial_merkle_tree.valid_tree?(@mrkl_root.reverse_hth)
         else
-          @mrkl_root.reverse_hth == Bitcoin.hash_mrkl_tree( @tx.map(&:hash) ).last
+          @mrkl_root.reverse_hth == Bitcoin.hash_mrkl_tree(@tx.map(&:hash)).last
         end
       end
 
@@ -157,17 +164,21 @@ module Bitcoin
       # get the block header info
       # [<version>, <prev_block>, <merkle_root>, <time>, <bits>, <nonce>, <txcount>, <size>]
       def header_info
-        [@ver, @prev_block_hash.reverse_hth, @mrkl_root.reverse_hth, Time.at(@time), @bits, @nonce, @tx.size, @payload.size]
+        [
+          @ver, @prev_block_hash.reverse_hth, @mrkl_root.reverse_hth,
+          Time.at(@time), @bits, @nonce, @tx.size, @payload.size
+        ]
       end
 
       # convert to raw binary format
       def to_payload
         @aux_pow ||= nil
-        head = [@ver, @prev_block_hash, @mrkl_root, @time, @bits, @nonce].pack("Va32a32VVV")
-        head << @aux_pow.to_payload  if @aux_pow
-        return head if @tx.size == 0
+        head = [@ver, @prev_block_hash, @mrkl_root, @time, @bits, @nonce].pack('Va32a32VVV')
+        head << @aux_pow.to_payload if @aux_pow
+        return head if @tx.empty?
+
         head << Protocol.pack_var_int(@tx.size)
-        @tx.each{|tx| head << tx.to_payload }
+        @tx.each { |tx| head << tx.to_payload }
         head
       end
 
@@ -177,11 +188,11 @@ module Bitcoin
           'hash' => @hash, 'ver' => @ver,
           'prev_block' => @prev_block_hash.reverse_hth, 'mrkl_root' => @mrkl_root.reverse_hth,
           'time' => @time, 'bits' => @bits, 'nonce' => @nonce,
-          'n_tx' => @tx.size, 'size' => (@payload||to_payload).bytesize,
-          'tx' => @tx.map{|i| i.to_hash(options) },
-          'mrkl_tree' => Bitcoin.hash_mrkl_tree( @tx.map{|i| i.hash } )
+          'n_tx' => @tx.size, 'size' => (@payload || to_payload).bytesize,
+          'tx' => @tx.map { |i| i.to_hash(options) },
+          'mrkl_tree' => Bitcoin.hash_mrkl_tree(@tx.map(&:hash))
         }
-        h['aux_pow'] = @aux_pow.to_hash  if @aux_pow
+        h['aux_pow'] = @aux_pow.to_hash if @aux_pow
         h
       end
 
@@ -204,75 +215,90 @@ module Bitcoin
       # introduced in block version 2 by BIP_0034
       # blockchain height as seen by the block itself.
       # do not trust this value, instead verify with chain storage.
-      def bip34_block_height(height=nil)
+      def bip34_block_height(height = nil)
         return nil unless @ver >= 2
         if height # generate height binary
-          buf = [height].pack("V").gsub(/\x00+$/,"")
-          [buf.bytesize, buf].pack("Ca*")
+          buf = [height].pack('V').gsub(/\x00+$/, '')
+          [buf.bytesize, buf].pack('Ca*')
         else
           coinbase = @tx.first.inputs.first.script_sig
-          coinbase[1..coinbase[0].ord].ljust(4, "\x00").unpack("V").first
+          coinbase[1..coinbase[0].ord].ljust(4, "\x00").unpack('V').first
         end
-      rescue
+      rescue StandardError
         nil
       end
 
       # convert to json representation as seen in the block explorer.
       # (see also #from_json)
-      def to_json(options = {:space => ''}, *a)
-        JSON.pretty_generate( to_hash(options), options )
+      def to_json(options = { space: '' }, *_)
+        JSON.pretty_generate(to_hash(options), options)
       end
 
       # write json representation to a file
       # (see also #to_json)
       def to_json_file(path)
-        File.open(path, 'wb'){|f| f.print to_json; }
+        File.open(path, 'wb') { |f| f.print to_json; }
       end
 
       # parse ruby hash (see also #to_hash)
-      def self.from_hash(h, do_raise=true)
+      def self.from_hash(h, do_raise = true)
         blk = new(nil)
-        blk.instance_eval{
+        blk.instance_eval do
           @ver, @time, @bits, @nonce = h.values_at('ver', 'time', 'bits', 'nonce')
-          @prev_block_hash, @mrkl_root = h.values_at('prev_block', 'mrkl_root').map{|i| i.htb_reverse }
-          unless h['hash'] == recalc_block_hash
-            raise "Block hash mismatch! Claimed: #{h['hash']}, Actual: #{@hash}" if do_raise
+          @prev_block_hash, @mrkl_root = h.values_at('prev_block', 'mrkl_root').map(&:htb_reverse)
+
+          if do_raise && h['hash'] != recalc_block_hash
+            raise "Block hash mismatch! Claimed: #{h['hash']}, Actual: #{@hash}"
           end
-          @aux_pow = AuxPow.from_hash(h['aux_pow'])  if h['aux_pow']
-          h['tx'].each{|tx| @tx << Tx.from_hash(tx, do_raise) }
-          if h['tx'].any?
-            (raise "Block merkle root mismatch! Block: #{h['hash']}"  unless verify_mrkl_root) if do_raise
+
+          @aux_pow = AuxPow.from_hash(h['aux_pow']) if h['aux_pow']
+
+          h['tx'].each { |tx| @tx << Tx.from_hash(tx, do_raise) }
+          if h['tx'].any? && do_raise && !verify_mrkl_root
+            raise "Block merkle root mismatch! Block: #{h['hash']}"
           end
-        }
+        end
         blk
       end
 
       # convert ruby hash to raw binary
-      def self.binary_from_hash(h); from_hash(h).to_payload; end
+      def self.binary_from_hash(h)
+        from_hash(h).to_payload
+      end
 
       # parse json representation (see also #to_json)
-      def self.from_json(json_string); from_hash( JSON.load(json_string) ); end
+      def self.from_json(json_string)
+        from_hash(JSON.parse(json_string))
+      end
 
       # convert json representation to raw binary
-      def self.binary_from_json(json_string); from_json(json_string).to_payload; end
+      def self.binary_from_json(json_string)
+        from_json(json_string).to_payload
+      end
 
       # convert header to json representation.
-      def header_to_json(options = {:space => ''})
+      def header_to_json(options = { space: '' })
         h = to_hash
-        %w[tx mrkl_tree].each{|k| h.delete(k) }
-        JSON.pretty_generate( h, options )
+        %w[tx mrkl_tree].each { |k| h.delete(k) }
+        JSON.pretty_generate(h, options)
       end
 
       # block header binary output
       def block_header
-        [@ver, @prev_block_hash, @mrkl_root, @time, @bits, @nonce, Protocol.pack_var_int(0)].pack("Va32a32VVVa*")
+        [
+          @ver, @prev_block_hash, @mrkl_root, @time, @bits, @nonce, Protocol.pack_var_int(0)
+        ].pack('Va32a32VVVa*')
       end
 
       # read binary block from a file
-      def self.from_file(path); new( Bitcoin::Protocol.read_binary_file(path) ); end
+      def self.from_file(path)
+        new(Bitcoin::Protocol.read_binary_file(path))
+      end
 
       # read json block from a file
-      def self.from_json_file(path); from_json( Bitcoin::Protocol.read_binary_file(path) ); end
+      def self.from_json_file(path)
+        from_json(Bitcoin::Protocol.read_binary_file(path))
+      end
 
       # get the (statistical) amount of work that was needed to generate this block.
       def block_work
@@ -280,8 +306,6 @@ module Bitcoin
         return 0 if target <= 0
         (2**256) / (target + 1)
       end
-
     end
-
   end
 end

--- a/lib/bitcoin/protocol/handler.rb
+++ b/lib/bitcoin/protocol/handler.rb
@@ -2,7 +2,7 @@
 
 module Bitcoin
   module Protocol
-
+    # https://en.bitcoin.it/wiki/Protocol_documentation#Message_types
     class Handler
       def on_inv_transaction(hash)
         p ['inv transaction', hash.hth]
@@ -29,15 +29,13 @@ module Bitcoin
       end
 
       def on_block(block)
-        #p ['block', block]
+        # p ['block', block]
         puts block.to_json
       end
 
       def on_error(message, payload)
         p ['error', message, payload]
       end
-
     end
-
   end
 end

--- a/lib/bitcoin/protocol/parser.rb
+++ b/lib/bitcoin/protocol/parser.rb
@@ -86,7 +86,7 @@ module Bitcoin
         payload.each_byte.each_slice(30) do |i|
           begin
             @h.on_addr(Addr.new(i.pack('C*')))
-          rescue
+          rescue StandardError
             parse_error(:addr, i.pack('C*'))
           end
         end
@@ -206,6 +206,6 @@ module Bitcoin
         return unless @h.respond_to?(:on_error)
         @h.on_error(*err)
       end
-    end # Parser
+    end
   end
 end

--- a/lib/bitcoin/protocol/parser.rb
+++ b/lib/bitcoin/protocol/parser.rb
@@ -2,21 +2,66 @@
 
 module Bitcoin
   module Protocol
-
+    # https://en.bitcoin.it/wiki/Protocol_documentation#Message_types
     class Parser
       attr_reader :stats
 
-      def initialize(handler=nil)
+      def initialize(handler = nil)
         @h = handler || Handler.new
-        @buf = ""
+        @buf = ''
         @stats = { 'total_packets' => 0, 'total_bytes' => 0, 'total_errors' => 0 }
       end
 
+      # rubocop:disable CyclomaticComplexity
+      def process_pkt(command, payload)
+        @stats['total_packets'] += 1
+        @stats['total_bytes'] += payload.bytesize
+        @stats[command] ? (@stats[command] += 1) : @stats[command] = 1
+        case command
+        when 'tx' then @h.on_tx(Tx.new(payload))
+        when 'block' then @h.on_block(Block.new(payload))
+        when 'headers' then parse_headers(payload)
+        when 'inv' then parse_inv(payload, :put)
+        when 'getdata' then parse_inv(payload, :get)
+        when 'addr' then parse_addr(payload)
+        when 'getaddr' then @h.on_getaddr if @h.respond_to?(:on_getaddr)
+        when 'verack' then parse_verack
+        when 'version' then parse_version(payload)
+        when 'alert' then parse_alert(payload)
+        when 'ping' then @h.on_ping(payload.unpack('Q')[0])
+        when 'pong' then @h.on_pong(payload.unpack('Q')[0])
+        when 'getblocks' then @h.on_getblocks(*parse_getblocks(payload)) \
+          if @h.respond_to?(:on_getblocks)
+        when 'getheaders' then @h.on_getheaders(*parse_getblocks(payload)) \
+          if @h.respond_to?(:on_getheaders)
+        when 'mempool' then handle_mempool_request(payload)
+        when 'notfound' then handle_notfound_reply(payload)
+        when 'merkleblock' then parse_mrkle_block(payload)
+        when 'reject' then handle_reject(payload)
+        else
+          parse_error :unknown_packet, [command, payload.hth]
+        end
+      end
+      # rubocop:enable CyclomaticComplexity
+
+      def parse_headers(payload)
+        return unless @h.respond_to?(:on_headers)
+        buf = StringIO.new(payload)
+        count = Protocol.unpack_var_int_from_io(buf)
+        headers = Array.new(count) do
+          break if buf.eof?
+          b = Block.new
+          b.parse_data_from_io(buf, true)
+          b
+        end
+        @h.on_headers(headers)
+      end
+
       # handles inv/getdata packets
-      def parse_inv(payload, type=:put)
+      def parse_inv(payload, type = :put)
         count, payload = Protocol.unpack_var_int(payload)
         payload.each_byte.each_slice(36).with_index do |i, idx|
-          hash = i[4..-1].reverse.pack("C32")
+          hash = i[4..-1].reverse.pack('C32')
           case i[0]
           when 1
             type == :put ? @h.on_inv_transaction(hash) : @h.on_get_transaction(hash)
@@ -31,7 +76,7 @@ module Bitcoin
               @h.on_get_block(hash)
             end
           else
-            parse_error :parse_inv, i.pack("C*")
+            parse_error :parse_inv, i.pack('C*')
           end
         end
       end
@@ -39,62 +84,19 @@ module Bitcoin
       def parse_addr(payload)
         _, payload = Protocol.unpack_var_int(payload)
         payload.each_byte.each_slice(30) do |i|
-          @h.on_addr(Addr.new(i.pack("C*"))) rescue parse_error(:addr, i.pack("C*"))
+          begin
+            @h.on_addr(Addr.new(i.pack('C*')))
+          rescue
+            parse_error(:addr, i.pack('C*'))
+          end
         end
       end
 
-      def parse_headers(payload)
-        return unless @h.respond_to?(:on_headers)
-        buf = StringIO.new(payload)
-        count = Protocol.unpack_var_int_from_io(buf)
-        headers = count.times.map{
-          break if buf.eof?
-          b = Block.new; b.parse_data_from_io(buf, true); b
-        }
-        @h.on_headers(headers)
-      end
-
-      def parse_mrkle_block(payload)
-        return unless @h.respond_to?(:on_mrkle_block)
-        b = Block.new
-        b.parse_data_from_io(payload, :filtered)
-        @h.on_mrkle_block(b)
-      end
-
-      def parse_getblocks(payload)
-        version, payload = payload.unpack('Va*')
-        count,   payload = Protocol.unpack_var_int(payload)
-        buf,     payload = payload.unpack("a#{count*32}a*")
-        hashes    = buf.each_byte.each_slice(32).map{|i| i.reverse.pack("C32").hth }
-        stop_hash = payload[0..32].reverse_hth
-        [version, hashes, stop_hash]
-      end
-
-      def process_pkt(command, payload)
-        @stats['total_packets'] += 1
-        @stats['total_bytes'] += payload.bytesize
-        @stats[command] ? (@stats[command] += 1) : @stats[command] = 1
-        case command
-        when 'tx';       @h.on_tx( Tx.new(payload) )
-        when 'block';    @h.on_block( Block.new(payload) )
-        when 'headers';  parse_headers(payload)
-        when 'inv';      parse_inv(payload, :put)
-        when 'getdata';  parse_inv(payload, :get)
-        when 'addr';     parse_addr(payload)
-        when 'getaddr';  @h.on_getaddr  if @h.respond_to?(:on_getaddr)
-        when 'verack';   @h.respond_to?(:on_verack) ? @h.on_verack : (@h.respond_to?(:on_handshake_complete) ? @h.on_handshake_complete : nil)
-        when 'version';  parse_version(payload)
-        when 'alert';    parse_alert(payload)
-        when 'ping';     @h.on_ping(payload.unpack("Q")[0])
-        when 'pong';     @h.on_pong(payload.unpack("Q")[0])
-        when 'getblocks';   @h.on_getblocks(*parse_getblocks(payload))  if @h.respond_to?(:on_getblocks)
-        when 'getheaders';  @h.on_getheaders(*parse_getblocks(payload))  if @h.respond_to?(:on_getheaders)
-        when 'mempool';  handle_mempool_request(payload)
-        when 'notfound'; handle_notfound_reply(payload)
-        when 'merkleblock'; parse_mrkle_block(payload)
-        when 'reject'; handle_reject(payload)
+      def parse_verack
+        if @h.respond_to?(:on_verack)
+          @h.on_verack
         else
-          parse_error :unknown_packet, [command, payload.hth]
+          @h.respond_to?(:on_handshake_complete) ? @h.on_handshake_complete : nil
         end
       end
 
@@ -108,15 +110,21 @@ module Bitcoin
         @h.on_alert Bitcoin::Protocol::Alert.parse(payload)
       end
 
-      def handle_reject(payload)
-        return unless @h.respond_to?(:on_reject)
-        @h.on_reject Bitcoin::Protocol::Reject.parse(payload)
+      def parse_getblocks(payload)
+        version, payload = payload.unpack('Va*')
+        count, payload = Protocol.unpack_var_int(payload)
+        buf, payload = payload.unpack("a#{count * 32}a*")
+        hashes = buf.each_byte.each_slice(32).map { |i| i.reverse.pack('C32').hth }
+        stop_hash = payload[0..32].reverse_hth
+        [version, hashes, stop_hash]
       end
 
       # https://en.bitcoin.it/wiki/BIP_0035
-      def handle_mempool_request(payload)
-        return unless @version.fields[:version] >= 60002           # Protocol version >= 60002
-        return unless (@version.fields[:services] & Bitcoin::Protocol::Version::NODE_NETWORK) == 1 # NODE_NETWORK bit set in Services
+      def handle_mempool_request(*_)
+        return unless @version.fields[:version] >= 60_002 # Protocol version >= 60002
+        return unless (
+          @version.fields[:services] & Bitcoin::Protocol::Version::NODE_NETWORK
+        ) == 1 # NODE_NETWORK bit set in Services
         @h.on_mempool if @h.respond_to?(:on_mempool)
       end
 
@@ -124,14 +132,26 @@ module Bitcoin
         return unless @h.respond_to?(:on_notfound)
         _, payload = Protocol.unpack_var_int(payload)
         payload.each_byte.each_slice(36) do |i|
-          hash = i[4..-1].reverse.pack("C32")
+          hash = i[4..-1].reverse.pack('C32')
           case i[0]
-          when 1; @h.on_notfound(:tx, hash)
-          when 2; @h.on_notfound(:block, hash)
+          when 1 then @h.on_notfound(:tx, hash)
+          when 2 then @h.on_notfound(:block, hash)
           else
-            parse_error(:notfound, [i.pack("C*"), hash])
+            parse_error(:notfound, [i.pack('C*'), hash])
           end
         end
+      end
+
+      def parse_mrkle_block(payload)
+        return unless @h.respond_to?(:on_mrkle_block)
+        b = Block.new
+        b.parse_data_from_io(payload, :filtered)
+        @h.on_mrkle_block(b)
+      end
+
+      def handle_reject(payload)
+        return unless @h.respond_to?(:on_reject)
+        @h.on_reject Bitcoin::Protocol::Reject.parse(payload)
       end
 
       def parse(buf)
@@ -141,34 +161,34 @@ module Bitcoin
       end
 
       def parse_buffer
-        head_magic = Bitcoin::network[:magic_head]
+        head_magic = Bitcoin.network[:magic_head]
         head_size  = 24
         return false if @buf.size < head_size
 
-        magic, cmd, length, checksum = @buf.unpack("a4A12Va4")
-        payload = @buf[head_size...head_size+length]
+        magic, cmd, length, checksum = @buf.unpack('a4A12Va4')
+        payload = @buf[head_size...head_size + length]
 
-        unless magic == head_magic
-          handle_stream_error(:close, "head_magic not found")
-          @buf = ''
-        else
+        if magic == head_magic
 
-          if Digest::SHA256.digest(Digest::SHA256.digest( payload ))[0...4] != checksum
-            if (length < 50000) && (payload.size < length)
+          if Digest::SHA256.digest(Digest::SHA256.digest(payload))[0...4] != checksum
+            if (length < 50_000) && (payload.size < length)
               size_info = [payload.size, length].join('/')
               handle_stream_error(:debug, "chunked packet stream (#{size_info})")
             else
-              handle_stream_error(:close, "checksum mismatch")
+              handle_stream_error(:close, 'checksum mismatch')
             end
             return
           end
-          @buf = @buf[head_size+length..-1] || ""
+          @buf = @buf[head_size + length..-1] || ''
 
           process_pkt(cmd, payload)
+        else
+          handle_stream_error(:close, 'head_magic not found')
+          @buf = ''
         end
 
         # not empty yet? parse more.
-        @buf[0] != nil
+        !@buf[0].nil?
       end
 
       def handle_stream_error(type, msg)
@@ -186,8 +206,6 @@ module Bitcoin
         return unless @h.respond_to?(:on_error)
         @h.on_error(*err)
       end
-
     end # Parser
-
   end
 end

--- a/lib/bitcoin/protocol/partial_merkle_tree.rb
+++ b/lib/bitcoin/protocol/partial_merkle_tree.rb
@@ -1,61 +1,73 @@
-class Bitcoin::Protocol::PartialMerkleTree
-  Node = Struct.new(:value, :left, :right, :width_idx)
+module Bitcoin
+  module Protocol
+    # https://en.bitcoin.it/wiki/Protocol_documentation#Merkle_Trees
+    class PartialMerkleTree
+      Node = Struct.new(:value, :left, :right, :width_idx)
 
-  BIT_MASK = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80]
+      BIT_MASK = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80].freeze
 
-  def initialize(total_txs, hashes, flags)
-    @total_txs, @flags = total_txs, flags
-    @hashes = hashes.map{|h| h.reverse_hth }
-    @visit_idx = 0
-  end
+      def initialize(total_txs, hashes, flags)
+        @total_txs = total_txs
+        @flags = flags
+        @hashes = hashes.map(&:reverse_hth)
+        @visit_idx = 0
+      end
 
-  def tx_hashes
-    @leaves.reject{|n| n.value.nil? }.map{|n| n.value }
-  end
+      def tx_hashes
+        @leaves.reject { |n| n.value.nil? }.map(&:value)
+      end
 
-  def build_tree
-    lay = @leaves = @total_txs.times.map{ Node.new(nil, nil, nil) }
-    while lay.size > 1
-      lay = lay.each_slice(2).map do |left, right|
-        Node.new(nil, left, right)
+      def build_tree
+        lay = @leaves = Array.new(@total_txs) { Node.new(nil, nil, nil) }
+        while lay.size > 1
+          lay = lay.each_slice(2).map do |left, right|
+            Node.new(nil, left, right)
+          end
+        end
+        lay[0]
+      end
+
+      def current_flag
+        (@flags[@visit_idx / 8].ord & BIT_MASK[@visit_idx % 8]).zero?
+      end
+
+      def root
+        @root ||= build_tree
+      end
+
+      def set_value(node = root) # rubocop:disable Naming/AccessorMethodName
+        warn '[DEPRECATION] `PartialMerkleTree.set_value` is deprecated. ' \
+          'Use `assign_value` instead.'
+        assign_value(node)
+      end
+
+      def assign_value(node = root)
+        if current_flag || (node.left.nil? && node.right.nil?)
+          node.value = @hashes.shift
+          return
+        end
+
+        if node.left
+          @visit_idx += 1
+          assign_value(node.left)
+        end
+        if node.right
+          @visit_idx += 1
+          assign_value(node.right)
+        end
+
+        right = node.right || node.left
+        node.value = Bitcoin.bitcoin_mrkl(node.left.value, right.value)
+
+        nil
+      end
+
+      def valid_tree?(mrkl_root_hash)
+        return false unless @hashes.empty?
+        return false if ((@visit_idx + 1) / 8.0).ceil != @flags.length
+        return false if mrkl_root_hash != root.value
+        true
       end
     end
-    return lay[0]
-  end
-
-  def current_flag
-    @flags[@visit_idx / 8].ord & BIT_MASK[@visit_idx % 8] == 0
-  end
-
-  def root
-    @root ||= build_tree
-  end
-
-  def set_value(node = root)
-    if current_flag || (node.left.nil? && node.right.nil?)
-      node.value = @hashes.shift
-      return
-    end
-
-    if node.left
-      @visit_idx += 1
-      set_value(node.left)
-    end
-    if node.right
-      @visit_idx += 1
-      set_value(node.right)
-    end
-
-    right = node.right || node.left
-    node.value = Bitcoin.bitcoin_mrkl(node.left.value, right.value)
-
-    return
-  end
-
-  def valid_tree?(mrkl_root_hash)
-    return false unless @hashes.empty?
-    return false if ((@visit_idx + 1)/8.0).ceil != @flags.length
-    return false if mrkl_root_hash != root.value
-    return true
   end
 end

--- a/lib/bitcoin/protocol/reject.rb
+++ b/lib/bitcoin/protocol/reject.rb
@@ -1,38 +1,36 @@
 # encoding: ascii-8bit
 
 module Bitcoin
-module Protocol
+  module Protocol
+    Reject = Struct.new(:message, :ccode, :reason, :data) do
+      CCODE_TABLE = {
+        0x01 => :malformed,
+        0x10 => :invalid,
+        0x11 => :obsolete,
+        0x12 => :duplicate,
+        0x40 => :nonstandard,
+        0x41 => :dust,
+        0x42 => :insufficientfee,
+        0x43 => :checkpoint
+      }.freeze
 
-  class Reject < Struct.new(:message, :ccode, :reason, :data)
-    CCODE_TABLE = {
-      0x01 => :malformed,
-      0x10 => :invalid,
-      0x11 => :obsolete,
-      0x12 => :duplicate,
-      0x40 => :nonstandard,
-      0x41 => :dust,
-      0x42 => :insufficientfee,
-      0x43 => :checkpoint,
-    }
+      def self.parse(payload)
+        message, payload = Bitcoin::Protocol.unpack_var_string(payload)
+        ccode,   payload = payload.unpack('Ca*')
+        reason,  payload = Bitcoin::Protocol.unpack_var_string(payload)
+        data =   payload
 
-    def self.parse(payload)
-      message, payload = Bitcoin::Protocol.unpack_var_string(payload)
-      ccode,   payload = payload.unpack("Ca*")
-      reason,  payload = Bitcoin::Protocol.unpack_var_string(payload)
-      data =   payload
+        code = CCODE_TABLE[ccode] || ccode
+        new(message, code, reason, data)
+      end
 
-      code = CCODE_TABLE[ccode] || ccode
-      new(message, code, reason, data)
-    end
+      def tx_hash
+        message == 'tx' && self[:data].reverse.bth
+      end
 
-    def tx_hash
-      message == "tx" && self[:data].reverse.bth
-    end
-
-    def block_hash
-      message == "block" && self[:data].reverse.bth
+      def block_hash
+        message == 'block' && self[:data].reverse.bth
+      end
     end
   end
-
-end
 end

--- a/lib/bitcoin/protocol/script_witness.rb
+++ b/lib/bitcoin/protocol/script_witness.rb
@@ -1,11 +1,9 @@
 # encoding: ascii-8bit
 
 module Bitcoin
-
   module Protocol
-
+    # TxWitness section of https://en.bitcoin.it/wiki/Protocol_documentation#tx
     class ScriptWitness
-
       # witness stack
       attr_reader :stack
 
@@ -21,11 +19,8 @@ module Bitcoin
       # output script in raw binary format
       def to_payload
         payload = Bitcoin::Protocol.pack_var_int(stack.size)
-        payload << stack.map{|e| Bitcoin::Protocol.pack_var_int(e.bytesize) << e }.join
+        payload << stack.map { |e| Bitcoin::Protocol.pack_var_int(e.bytesize) << e }.join
       end
-
     end
-
   end
-
 end

--- a/lib/bitcoin/protocol/tx.rb
+++ b/lib/bitcoin/protocol/tx.rb
@@ -4,9 +4,8 @@ require 'bitcoin/script'
 
 module Bitcoin
   module Protocol
-
+    # https://en.bitcoin.it/wiki/Protocol_documentation#tx
     class Tx
-
       MARKER = 0
       FLAG = 1
 
@@ -36,8 +35,8 @@ module Bitcoin
       attr_accessor :marker
       attr_accessor :flag
 
-      alias :inputs  :in
-      alias :outputs :out
+      alias inputs  in
+      alias outputs out
 
       # compare to another tx
       def ==(other)
@@ -46,19 +45,23 @@ module Bitcoin
 
       # return the tx hash in binary format
       def binary_hash
-        @binary_hash ||= [@hash].pack("H*").reverse
+        @binary_hash ||= [@hash].pack('H*').reverse
       end
 
       # create tx from raw binary +data+
-      def initialize(data=nil)
-        @ver, @lock_time, @in, @out, @scripts = 1, 0, [], [], []
-        @enable_bitcoinconsensus = !!ENV['USE_BITCOINCONSENSUS']
+      def initialize(data = nil)
+        @ver = 1
+        @lock_time = 0
+        @in = []
+        @out = []
+        @scripts = []
+        @enable_bitcoinconsensus = !ENV['USE_BITCOINCONSENSUS'].nil?
         parse_data_from_io(data) if data
       end
 
       # generate the tx hash for given +payload+ in hex format
       def hash_from_payload(payload)
-        Digest::SHA256.digest(Digest::SHA256.digest( payload )).reverse_hth
+        Digest::SHA256.digest(Digest::SHA256.digest(payload)).reverse_hth
       end
       alias generate_hash hash_from_payload
 
@@ -68,26 +71,31 @@ module Bitcoin
       end
 
       # add an input
-      def add_in(input); (@in ||= []) << input; end
+      def add_in(input)
+        (@in ||= []) << input
+      end
 
       # add an output
-      def add_out(output); (@out ||= []) << output; end
+      def add_out(output)
+        (@out ||= []) << output
+      end
 
       # parse raw binary data
+      # rubocop:disable CyclomaticComplexity,PerceivedComplexity
       def parse_data_from_io(data)
         buf = data.is_a?(String) ? StringIO.new(data) : data
 
-        @ver = buf.read(4).unpack("V")[0]
+        @ver = buf.read(4).unpack('V')[0]
 
         return false if buf.eof?
 
         # segwit serialization format is defined by https://github.com/bitcoin/bips/blob/master/bip-0144.mediawiki
-        # Also note that it is impossible to parse 0 input transactions. Regular transactions with 0 inputs look
-        # like malformed segwit transactions.
+        # Also note that it is impossible to parse 0 input transactions. Regular transactions
+        # with 0 inputs look like malformed segwit transactions.
         @marker = buf.read(1).unpack('c').first
         @flag = buf.read(1).unpack('c').first
 
-        witness = @marker == 0 && @flag != 0
+        witness = @marker.zero? && !@flag.zero?
 
         # Non-segwit format does not contain marker or flag fields.
         buf.seek(buf.pos - 2) unless witness
@@ -95,19 +103,19 @@ module Bitcoin
         in_size = Protocol.unpack_var_int_from_io(buf)
 
         @in = []
-        in_size.times{
+        in_size.times do
           break if buf.eof?
           @in << TxIn.from_io(buf)
-        }
+        end
 
         return false if buf.eof?
 
         out_size = Protocol.unpack_var_int_from_io(buf)
         @out = []
-        out_size.times{
+        out_size.times do
           break if buf.eof?
           @out << TxOut.from_io(buf)
-        }
+        end
 
         return false if buf.eof?
 
@@ -121,7 +129,7 @@ module Bitcoin
           end
         end
 
-        @lock_time = buf.read(4).unpack("V")[0]
+        @lock_time = buf.read(4).unpack('V')[0]
 
         @hash = hash_from_payload(to_old_payload)
         @payload = to_payload
@@ -132,8 +140,9 @@ module Bitcoin
           data.is_a?(StringIO) ? buf : buf.read
         end
       end
+      # rubocop:enable CyclomaticComplexity,PerceivedComplexity
 
-      alias :parse_data  :parse_data_from_io
+      alias parse_data parse_data_from_io
 
       # output transaction in raw binary format
       def to_payload
@@ -141,12 +150,14 @@ module Bitcoin
       end
 
       def to_old_payload
-        pin = ""
-        @in.each{|input| pin << input.to_payload }
-        pout = ""
-        @out.each{|output| pout << output.to_payload }
+        pin = ''
+        @in.each { |input| pin << input.to_payload }
+        pout = ''
+        @out.each { |output| pout << output.to_payload }
 
-        [@ver].pack("V") << Protocol.pack_var_int(@in.size) << pin << Protocol.pack_var_int(@out.size) << pout << [@lock_time].pack("V")
+        [@ver].pack('V') << Protocol.pack_var_int(@in.size) \
+                         << pin << Protocol.pack_var_int(@out.size) \
+                         << pout << [@lock_time].pack('V')
       end
 
       # output transaction in raw binary format with witness
@@ -168,7 +179,10 @@ module Bitcoin
 
       # generate a signature hash for input +input_idx+.
       # either pass the +outpoint_tx+ or the +script_pubkey+ directly.
-      def signature_hash_for_input(input_idx, subscript, hash_type=nil, prev_out_value=nil, fork_id=nil)
+      # rubocop:disable CyclomaticComplexity,PerceivedComplexity
+      def signature_hash_for_input(
+        input_idx, subscript, hash_type = nil, prev_out_value = nil, fork_id = nil
+      )
         # https://github.com/bitcoin/bitcoin/blob/e071a3f6c06f41068ad17134189a4ac3073ef76b/script.cpp#L834
         # http://code.google.com/p/bitcoinj/source/browse/trunk/src/com/google/bitcoin/core/Script.java#318
         # https://en.bitcoin.it/wiki/OP_CHECKSIG#How_it_works
@@ -181,31 +195,34 @@ module Bitcoin
         # Bitcoin Cash protocol will be respected.
         #
         # https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/doc/abc/replay-protected-sighash.md
-        if fork_id && (hash_type&SIGHASH_TYPE[:forkid]) != 0
-          raise "SIGHASH_FORKID is enabled, so prev_out_value is required" if prev_out_value.nil?
+        if fork_id && (hash_type & SIGHASH_TYPE[:forkid]) != 0
+          raise 'SIGHASH_FORKID is enabled, so prev_out_value is required' if prev_out_value.nil?
 
           # According to the spec, we should modify the sighash by replacing the 24 most significant
           # bits with the fork ID. However, Bitcoin ABC does not currently implement this since the
           # fork_id is an implicit 0 and it would make the sighash JSON tests fail. Will leave as a
           # TODO for now.
-          raise NotImplementedError, "fork_id must be 0" unless fork_id == 0
+          raise NotImplementedError, 'fork_id must be 0' unless fork_id.zero?
 
           script_code = Bitcoin::Protocol.pack_var_string(subscript)
           return signature_hash_for_input_bip143(input_idx, script_code, prev_out_value, hash_type)
         end
 
         # Note: BitcoinQT checks if input_idx >= @in.size and returns 1 with an error message.
-        # But this check is never actually useful because BitcoinQT would crash 
-        # right before VerifyScript if input index is out of bounds (inside CScriptCheck::operator()()).
+        # But this check is never actually useful because BitcoinQT would crash right before
+        # VerifyScript if input index is out of bounds (inside CScriptCheck::operator()()).
         # That's why we don't need to do such a check here.
         #
-        # However, if you look at the case SIGHASH_TYPE[:single] below, we must 
-        # return 1 because it's possible to have more inputs than outputs and BitcoinQT returns 1 as well.
-        return "\x01".ljust(32, "\x00") if input_idx >= @in.size # ERROR: SignatureHash() : input_idx=%d out of range
+        # However, if you look at the case SIGHASH_TYPE[:single] below, we must return 1
+        # because it's possible to have more inputs than outputs and BitcoinQT returns 1 as well.
 
-        pin  = @in.map.with_index{|input,idx|
+        # ERROR: SignatureHash() : input_idx=%d out of range
+        return "\x01".ljust(32, "\x00") if input_idx >= @in.size
+
+        pin = @in.map.with_index do |input, idx|
           if idx == input_idx
-            subscript = subscript.out[ input.prev_out_index ].script if subscript.respond_to?(:out) # legacy api (outpoint_tx)
+            # legacy api (outpoint_tx)
+            subscript = subscript.out[input.prev_out_index].script if subscript.respond_to?(:out)
 
             # Remove all instances of OP_CODESEPARATOR from the script.
             parsed_subscript = Script.new(subscript)
@@ -215,67 +232,93 @@ module Bitcoin
             input.to_payload(subscript)
           else
             case (hash_type & 0x1f)
-            when SIGHASH_TYPE[:none];   input.to_payload("", "\x00\x00\x00\x00")
-            when SIGHASH_TYPE[:single]; input.to_payload("", "\x00\x00\x00\x00")
-            else;                       input.to_payload("")
+            when SIGHASH_TYPE[:none] then   input.to_payload('', "\x00\x00\x00\x00")
+            when SIGHASH_TYPE[:single] then input.to_payload('', "\x00\x00\x00\x00")
+            else; input.to_payload('')
             end
           end
-        }
+        end
 
         pout = @out.map(&:to_payload)
-        in_size, out_size = Protocol.pack_var_int(@in.size), Protocol.pack_var_int(@out.size)
+        in_size = Protocol.pack_var_int(@in.size)
+        out_size = Protocol.pack_var_int(@out.size)
 
         case (hash_type & 0x1f)
         when SIGHASH_TYPE[:none]
-          pout = ""
+          pout = ''
           out_size = Protocol.pack_var_int(0)
         when SIGHASH_TYPE[:single]
-          return "\x01".ljust(32, "\x00") if input_idx >= @out.size # ERROR: SignatureHash() : input_idx=%d out of range (SIGHASH_SINGLE)
-          pout = @out[0...(input_idx+1)].map.with_index{|out,idx| (idx==input_idx) ? out.to_payload : out.to_null_payload }.join
-          out_size = Protocol.pack_var_int(input_idx+1)
+          # ERROR: SignatureHash() : input_idx=%d out of range (SIGHASH_SINGLE)
+          return "\x01".ljust(32, "\x00") if input_idx >= @out.size
+
+          pout = @out[0...(input_idx + 1)].map.with_index do |out, idx|
+            idx == input_idx ? out.to_payload : out.to_null_payload
+          end.join
+
+          out_size = Protocol.pack_var_int(input_idx + 1)
         end
 
         if (hash_type & SIGHASH_TYPE[:anyonecanpay]) != 0
-          in_size, pin = Protocol.pack_var_int(1), [ pin[input_idx] ]
+          in_size = Protocol.pack_var_int(1)
+          pin = [pin[input_idx]]
         end
 
-        buf = [ [@ver].pack("V"), in_size, pin, out_size, pout, [@lock_time, hash_type].pack("VV") ].join
-        Digest::SHA256.digest( Digest::SHA256.digest( buf ) )
+        buf = [
+          [@ver].pack('V'), in_size, pin, out_size,
+          pout, [@lock_time, hash_type].pack('VV')
+        ].join
+        Digest::SHA256.digest(Digest::SHA256.digest(buf))
       end
+      # rubocop:enable CyclomaticComplexity,PerceivedComplexity
 
       # generate a witness signature hash for input +input_idx+.
       # https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki
-      def signature_hash_for_witness_input(input_idx, witness_program, prev_out_value, witness_script = nil, hash_type=nil, skip_separator_index = 0)
-        return "\x01".ljust(32, "\x00") if input_idx >= @in.size # ERROR: SignatureHash() : input_idx=%d out of range
+      # rubocop:disable Metrics/ParameterLists
+      def signature_hash_for_witness_input(
+        input_idx, witness_program, prev_out_value,
+        witness_script = nil, hash_type = nil, skip_separator_index = 0
+      )
+        # ERROR: SignatureHash() : input_idx=%d out of range
+        return "\x01".ljust(32, "\x00") if input_idx >= @in.size
 
         hash_type ||= SIGHASH_TYPE[:all]
-
         script = Bitcoin::Script.new(witness_program)
-        raise "ScriptPubkey does not contain witness program." unless script.is_witness?
+        raise 'ScriptPubkey does not contain witness program.' unless script.is_witness?
 
         if script.is_witness_v0_keyhash?
-          script_code = [["1976a914", script.get_hash160, "88ac"].join].pack("H*")
+          script_code = [['1976a914', script.get_hash160, '88ac'].join].pack('H*')
         elsif script.is_witness_v0_scripthash?
-          raise "witness script does not match script pubkey" unless Bitcoin::Script.to_witness_p2sh_script(Digest::SHA256.digest(witness_script).bth) == witness_program
-          script = skip_separator_index > 0 ? Bitcoin::Script.new(witness_script).subscript_codeseparator(skip_separator_index) : witness_script
+          witness_pubkey_script_match = Bitcoin::Script.to_witness_p2sh_script(
+            Digest::SHA256.digest(witness_script).bth
+          ) == witness_program
+          raise 'witness script does not match script pubkey' unless witness_pubkey_script_match
+
+          script = if skip_separator_index > 0
+                     s = Bitcoin::Script.new(witness_script)
+                     s.subscript_codeseparator(skip_separator_index)
+                   else
+                     witness_script
+                   end
           script_code = Bitcoin::Protocol.pack_var_string(script)
         end
 
         signature_hash_for_input_bip143(input_idx, script_code, prev_out_value, hash_type)
       end
+      # rubocop:enable Metrics/ParameterLists
 
       # verify input signature +in_idx+ against the corresponding
       # output in +outpoint_tx+
       # outpoint. This arg can also be a Script or TxOut.
       #
-      # options are: verify_sigpushonly, verify_minimaldata, verify_cleanstack, verify_dersig, verify_low_s, verify_strictenc, fork_id
-      def verify_input_signature(in_idx, outpoint_data, block_timestamp=Time.now.to_i, opts={})
+      # options are: verify_sigpushonly, verify_minimaldata, verify_cleanstack,
+      #              verify_dersig, verify_low_s, verify_strictenc, fork_id
+      def verify_input_signature(in_idx, outpoint_data, block_timestamp = Time.now.to_i, opts = {})
         if @enable_bitcoinconsensus
           return bitcoinconsensus_verify_script(in_idx, outpoint_data, block_timestamp, opts)
         end
 
         # If FORKID is enabled, we also ensure strict encoding.
-        opts[:verify_strictenc] ||= !!opts[:fork_id]
+        opts[:verify_strictenc] ||= !opts[:fork_id].nil?
 
         outpoint_idx  = @in[in_idx].prev_out_index
         script_sig    = @in[in_idx].script_sig
@@ -284,29 +327,36 @@ module Bitcoin
         script_pubkey = script_pubkey_from_outpoint_data(outpoint_data, outpoint_idx)
 
         if opts[:fork_id] && amount.nil?
-          raise "verify_input_signature must be called with a previous transaction or " \
-            "transaction output if SIGHASH_FORKID is enabled"
+          raise 'verify_input_signature must be called with a previous transaction or ' \
+            'transaction output if SIGHASH_FORKID is enabled'
         end
 
         @scripts[in_idx] = Bitcoin::Script.new(script_sig, script_pubkey)
         return false if opts[:verify_sigpushonly] && !@scripts[in_idx].is_push_only?(script_sig)
         return false if opts[:verify_minimaldata] && !@scripts[in_idx].pushes_are_canonical?
-        sig_valid = @scripts[in_idx].run(block_timestamp, opts) do |pubkey,sig,hash_type,subscript|
+        sig_valid = @scripts[in_idx].run(
+          block_timestamp, opts
+        ) do |pubkey, sig, hash_type, subscript|
           hash = signature_hash_for_input(in_idx, subscript, hash_type, amount, opts[:fork_id])
-          Bitcoin.verify_signature( hash, sig, pubkey.unpack("H*")[0] )
+          Bitcoin.verify_signature(hash, sig, pubkey.unpack('H*')[0])
         end
         # BIP62 rule #6
         return false if opts[:verify_cleanstack] && !@scripts[in_idx].stack.empty?
 
-        return sig_valid
+        sig_valid
       end
 
       # verify witness input signature +in_idx+ against the corresponding
       # output in +outpoint_tx+
       # outpoint. This arg can also be a Script or TxOut
       #
-      # options are: verify_sigpushonly, verify_minimaldata, verify_cleanstack, verify_dersig, verify_low_s, verify_strictenc
-      def verify_witness_input_signature(in_idx, outpoint_data, prev_out_amount, block_timestamp=Time.now.to_i, opts={})
+      # options are: verify_sigpushonly, verify_minimaldata, verify_cleanstack,
+      #              verify_dersig, verify_low_s, verify_strictenc
+      #
+      # rubocop:disable CyclomaticComplexity,PerceivedComplexity
+      def verify_witness_input_signature(
+        in_idx, outpoint_data, prev_out_amount, block_timestamp = Time.now.to_i, opts = {}
+      )
         if @enable_bitcoinconsensus
           return bitcoinconsensus_verify_script(in_idx, outpoint_data, block_timestamp, opts)
         end
@@ -319,52 +369,69 @@ module Bitcoin
 
         if script_pubkey.is_p2sh?
           redeem_script = Bitcoin::Script.new(@in[in_idx].script_sig).get_pubkey
-          script_pubkey = Bitcoin::Script.new(redeem_script.htb) if Bitcoin.hash160(redeem_script) == script_pubkey.get_hash160 # P2SH-P2WPKH or P2SH-P2WSH
+
+          # P2SH-P2WPKH or P2SH-P2WSH
+          script_pubkey = if Bitcoin.hash160(redeem_script) == script_pubkey.get_hash160
+                            Bitcoin::Script.new(redeem_script.htb)
+                          end
         end
 
-        @in[in_idx].script_witness.stack.each{|s|script_sig << Bitcoin::Script.pack_pushdata(s)}
+        @in[in_idx].script_witness.stack.each { |s| script_sig << Bitcoin::Script.pack_pushdata(s) }
         code_separator_index = 0
 
         if script_pubkey.is_witness_v0_keyhash? # P2WPKH
-          @scripts[in_idx] = Bitcoin::Script.new(script_sig, Bitcoin::Script.to_hash160_script(script_pubkey.get_hash160))
+          @scripts[in_idx] = Bitcoin::Script.new(
+            script_sig, Bitcoin::Script.to_hash160_script(script_pubkey.get_hash160)
+          )
         elsif script_pubkey.is_witness_v0_scripthash? # P2WSH
           witness_hex = @in[in_idx].script_witness.stack.last.bth
           witness_script = Bitcoin::Script.new(witness_hex.htb)
           return false unless Bitcoin.sha256(witness_hex) == script_pubkey.get_hash160
-          @scripts[in_idx] = Bitcoin::Script.new(script_sig, Bitcoin::Script.to_p2sh_script(Bitcoin.hash160(witness_hex)))
+          @scripts[in_idx] = Bitcoin::Script.new(
+            script_sig, Bitcoin::Script.to_p2sh_script(Bitcoin.hash160(witness_hex))
+          )
         else
           return false
         end
 
         return false if opts[:verify_sigpushonly] && !@scripts[in_idx].is_push_only?(script_sig)
         return false if opts[:verify_minimaldata] && !@scripts[in_idx].pushes_are_canonical?
-        sig_valid = @scripts[in_idx].run(block_timestamp, opts) do |pubkey,sig,hash_type,subscript|
+        sig_valid = @scripts[in_idx].run(block_timestamp, opts) do |pubkey, sig, hash_type, _|
           if script_pubkey.is_witness_v0_keyhash?
-            hash = signature_hash_for_witness_input(in_idx, script_pubkey.to_payload, prev_out_amount, nil, hash_type)
+            hash = signature_hash_for_witness_input(
+              in_idx, script_pubkey.to_payload, prev_out_amount, nil, hash_type
+            )
           elsif script_pubkey.is_witness_v0_scripthash?
-            hash = signature_hash_for_witness_input(in_idx, script_pubkey.to_payload, prev_out_amount, witness_hex.htb, hash_type, code_separator_index)
+            hash = signature_hash_for_witness_input(
+              in_idx, script_pubkey.to_payload, prev_out_amount,
+              witness_hex.htb, hash_type, code_separator_index
+            )
             code_separator_index += 1 if witness_script.codeseparator_count > code_separator_index
           end
-          Bitcoin.verify_signature( hash, sig, pubkey.unpack("H*")[0] )
+          Bitcoin.verify_signature(hash, sig, pubkey.unpack('H*')[0])
         end
         # BIP62 rule #6
         return false if opts[:verify_cleanstack] && !@scripts[in_idx].stack.empty?
 
-        return sig_valid
+        sig_valid
       end
+      # rubocop:enable CyclomaticComplexity,PerceivedComplexity
 
-      def bitcoinconsensus_verify_script(in_idx, outpoint_data, block_timestamp=Time.now.to_i, opts={})
-        raise "Bitcoin::BitcoinConsensus shared library not found" unless Bitcoin::BitcoinConsensus.lib_available?
+      def bitcoinconsensus_verify_script(
+        in_idx, outpoint_data, block_timestamp = Time.now.to_i, opts = {}
+      )
+        consensus_available = Bitcoin::BitcoinConsensus.lib_available?
+        raise 'Bitcoin::BitcoinConsensus shared library not found' unless consensus_available
 
         outpoint_idx  = @in[in_idx].prev_out_index
         script_pubkey = script_pubkey_from_outpoint_data(outpoint_data, outpoint_idx)
 
         flags  = Bitcoin::BitcoinConsensus::SCRIPT_VERIFY_NONE
-        flags |= Bitcoin::BitcoinConsensus::SCRIPT_VERIFY_P2SH        if block_timestamp >= 1333238400
+        flags |= Bitcoin::BitcoinConsensus::SCRIPT_VERIFY_P2SH if block_timestamp >= 1_333_238_400
         flags |= Bitcoin::BitcoinConsensus::SCRIPT_VERIFY_SIGPUSHONLY if opts[:verify_sigpushonly]
         flags |= Bitcoin::BitcoinConsensus::SCRIPT_VERIFY_MINIMALDATA if opts[:verify_minimaldata]
-        flags |= Bitcoin::BitcoinConsensus::SCRIPT_VERIFY_CLEANSTACK  if opts[:verify_cleanstack]
-        flags |= Bitcoin::BitcoinConsensus::SCRIPT_VERIFY_LOW_S       if opts[:verify_low_s]
+        flags |= Bitcoin::BitcoinConsensus::SCRIPT_VERIFY_CLEANSTACK if opts[:verify_cleanstack]
+        flags |= Bitcoin::BitcoinConsensus::SCRIPT_VERIFY_LOW_S if opts[:verify_low_s]
 
         payload ||= to_payload
         Bitcoin::BitcoinConsensus.verify_script(in_idx, script_pubkey, payload, flags)
@@ -377,38 +444,37 @@ module Bitcoin
           'hash' => @hash, 'ver' => @ver, # 'nid' => normalized_hash,
           'vin_sz' => @in.size, 'vout_sz' => @out.size,
           'lock_time' => @lock_time, 'size' => (@payload ||= to_payload).bytesize,
-          'in'  =>  @in.map{|i|i.to_hash(options)},
-          'out' => @out.map{|o| o.to_hash(options) }
+          'in'  =>  @in.map { |i| i.to_hash(options) },
+          'out' => @out.map { |o| o.to_hash(options) }
         }
-        h['nid'] = normalized_hash  if options[:with_nid]
+        h['nid'] = normalized_hash if options[:with_nid]
         h
       end
 
       # generates rawblock json as seen in the block explorer.
-      def to_json(options = {:space => ''}, *a)
-        JSON.pretty_generate( to_hash(options), options )
+      def to_json(options = { space: '' }, *_a)
+        JSON.pretty_generate(to_hash(options), options)
       end
 
       # write json representation to a file
       # (see also #to_json)
       def to_json_file(path)
-        File.open(path, 'wb'){|f| f.print to_json; }
+        File.open(path, 'wb') { |f| f.print to_json; }
       end
 
       # parse ruby hash (see also #to_hash)
-      def self.from_hash(h, do_raise=true)
+      def self.from_hash(h, do_raise = true)
         tx = new(nil)
-        tx.ver, tx.lock_time = (h['ver'] || h['version']), h['lock_time']
+        tx.ver = (h['ver'] || h['version'])
+        tx.lock_time = h['lock_time']
         ins  = h['in']  || h['inputs']
         outs = h['out'] || h['outputs']
-        ins .each{|input|
-          tx.add_in(TxIn.from_hash(input))
-        }
-        outs.each{|output|  tx.add_out TxOut.from_hash(output) }
-        tx.instance_eval{
+        ins.each { |input| tx.add_in(TxIn.from_hash(input)) }
+        outs.each { |output| tx.add_out TxOut.from_hash(output) }
+        tx.instance_eval do
           @hash = hash_from_payload(to_old_payload)
           @payload = to_payload
-        }
+        end
         if h['hash'] && (h['hash'] != tx.hash)
           raise "Tx hash mismatch! Claimed: #{h['hash']}, Actual: #{tx.hash}" if do_raise
         end
@@ -422,61 +488,86 @@ module Bitcoin
       end
 
       # parse json representation
-      def self.from_json(json_string); from_hash( JSON.load(json_string) ); end
+      def self.from_json(json_string)
+        from_hash(JSON.parse(json_string))
+      end
 
       # convert json representation to raw binary
-      def self.binary_from_json(json_string); from_json(json_string).to_payload; end
+      def self.binary_from_json(json_string)
+        from_json(json_string).to_payload
+      end
 
       # read binary block from a file
-      def self.from_file(path); new( Bitcoin::Protocol.read_binary_file(path) ); end
+      def self.from_file(path)
+        new(Bitcoin::Protocol.read_binary_file(path))
+      end
 
       # read json block from a file
-      def self.from_json_file(path); from_json( Bitcoin::Protocol.read_binary_file(path) ); end
+      def self.from_json_file(path)
+        from_json(Bitcoin::Protocol.read_binary_file(path))
+      end
 
       def size
         payload.bytesize
       end
-      
-      # Checks if transaction is final taking into account height and time 
+
+      def is_final?(block_height, block_time) # rubocop:disable Naming/PredicateName
+        warn '[DEPRECATION] `Tx.is_final?` is deprecated. Use `final?` instead.'
+        final?(block_height, block_time)
+      end
+
+      # Checks if transaction is final taking into account height and time
       # of a block in which it is located (or about to be included if it's unconfirmed tx).
-      def is_final?(block_height, block_time)
+      def final?(block_height, block_time)
         # No time lock - tx is final.
-        return true if lock_time == 0
+        return true if lock_time.zero?
 
         # Time based nLockTime implemented in 0.1.6
         # If lock_time is below the magic threshold treat it as a block height.
         # If lock_time is above the threshold, it's a unix timestamp.
-        return true if lock_time < (lock_time < Bitcoin::LOCKTIME_THRESHOLD ? block_height : block_time)
+        lock_threshold = lock_time < Bitcoin::LOCKTIME_THRESHOLD ? block_height : block_time
+        return true if lock_time < lock_threshold
 
-        inputs.each{|input| return false if !input.is_final? }
+        inputs.each { |input| return false unless input.is_final? }
 
-        return true
+        true
       end
-      
+
       def legacy_sigops_count
-        # Note: input scripts normally never have any opcodes since every input script 
+        # Note: input scripts normally never have any opcodes since every input script
         # can be statically reduced to a pushdata-only script.
-        # However, anyone is allowed to create a non-standard transaction with any opcodes in the inputs.
+        # However, anyone is allowed to create a non-standard transaction
+        # with any opcodes in the inputs.
         count = 0
         self.in.each do |txin|
           count += Bitcoin::Script.new(txin.script_sig).sigops_count_accurate(false)
         end
-        self.out.each do |txout|
+        out.each do |txout|
           count += Bitcoin::Script.new(txout.pk_script).sigops_count_accurate(false)
         end
         count
       end
 
-      DEFAULT_BLOCK_PRIORITY_SIZE = 27000
+      DEFAULT_BLOCK_PRIORITY_SIZE = 27_000
 
-      def minimum_relay_fee; calculate_minimum_fee(true, :relay); end
-      def minimum_block_fee; calculate_minimum_fee(true, :block); end
+      def minimum_relay_fee
+        calculate_minimum_fee(true, :relay)
+      end
 
-      def calculate_minimum_fee(allow_free=true, mode=:block)
+      def minimum_block_fee
+        calculate_minimum_fee(true, :block)
+      end
+
+      # rubocop:disable PerceivedComplexity
+      def calculate_minimum_fee(allow_free = true, mode = :block)
         # Base fee is either nMinTxFee or nMinRelayTxFee
-        base_fee  = (mode == :relay) ? Bitcoin.network[:min_relay_tx_fee] : Bitcoin.network[:min_tx_fee]
-        tx_size   = to_payload.bytesize
-        min_fee   = (1 + tx_size / 1_000) * base_fee
+        base_fee = if mode == :relay
+                     Bitcoin.network[:min_relay_tx_fee]
+                   else
+                     Bitcoin.network[:min_tx_fee]
+                   end
+        tx_size = to_payload.bytesize
+        min_fee = (1 + tx_size / 1_000) * base_fee
 
         if allow_free
           # There is a free transaction area in blocks created by most miners,
@@ -485,7 +576,12 @@ module Bitcoin
           #   multiple transactions instead of one big transaction to avoid fees.
           # * If we are creating a transaction we allow transactions up to 1,000 bytes
           #   to be considered safe and assume they can likely make it into this section.
-          min_fee = 0 if tx_size < (mode == :block ? Bitcoin.network[:free_tx_bytes] : DEFAULT_BLOCK_PRIORITY_SIZE - 1_000)
+          min_free_size = if mode == :block
+                            Bitcoin.network[:free_tx_bytes]
+                          else
+                            DEFAULT_BLOCK_PRIORITY_SIZE - 1_000
+                          end
+          min_fee = 0 if tx_size < min_free_size
         end
 
         # This code can be removed after enough miners have upgraded to version 0.9.
@@ -505,18 +601,27 @@ module Bitcoin
           end
         end
 
-        min_fee = Bitcoin::network[:max_money] unless min_fee.between?(0, Bitcoin::network[:max_money])
+        min_fee = Bitcoin.network[:max_money] unless min_fee.between?(
+          0, Bitcoin.network[:max_money]
+        )
         min_fee
       end
+      # rubocop:enable PerceivedComplexity
 
-      def is_coinbase?
-        inputs.size == 1 and inputs.first.coinbase?
+      def is_coinbase? # rubocop:disable Naming/PredicateName
+        warn '[DEPRECATION] `Tx.is_coinbase?` is deprecated. Use `coinbase?` instead.'
+        coinbase?
+      end
+
+      def coinbase?
+        inputs.size == 1 && inputs.first.coinbase?
       end
 
       def normalized_hash
         signature_hash_for_input(-1, nil, SIGHASH_TYPE[:all]).reverse.hth
       end
-      alias :nhash :normalized_hash
+
+      alias nhash normalized_hash
 
       # get witness hash
       def witness_hash
@@ -526,37 +631,45 @@ module Bitcoin
       # sort transaction inputs and outputs under BIP 69
       # https://github.com/bitcoin/bips/blob/master/bip-0069.mediawiki
       def lexicographical_sort!
-        inputs.sort_by!{|i| [i.previous_output, i.prev_out_index]}
-        outputs.sort_by!{|o| [o.amount, o.pk_script.bth]}
+        inputs.sort_by! { |i| [i.previous_output, i.prev_out_index] }
+        outputs.sort_by! { |o| [o.amount, o.pk_script.bth] }
       end
 
       private
 
       def signature_hash_for_input_bip143(input_idx, script_code, prev_out_value, hash_type)
-        hash_prevouts = Digest::SHA256.digest(Digest::SHA256.digest(@in.map{|i| [i.prev_out_hash, i.prev_out_index].pack("a32V")}.join))
-        hash_sequence = Digest::SHA256.digest(Digest::SHA256.digest(@in.map{|i|i.sequence}.join))
-        outpoint = [@in[input_idx].prev_out_hash, @in[input_idx].prev_out_index].pack("a32V")
-        amount = [prev_out_value].pack("Q")
+        hash_prevouts = Digest::SHA256.digest(
+          Digest::SHA256.digest(
+            @in.map { |i| [i.prev_out_hash, i.prev_out_index].pack('a32V') }.join
+          )
+        )
+        hash_sequence = Digest::SHA256.digest(Digest::SHA256.digest(@in.map(&:sequence).join))
+        outpoint = [@in[input_idx].prev_out_hash, @in[input_idx].prev_out_index].pack('a32V')
+        amount = [prev_out_value].pack('Q')
         nsequence = @in[input_idx].sequence
 
-        hash_outputs = Digest::SHA256.digest(Digest::SHA256.digest(@out.map{|o|o.to_payload}.join))
+        hash_outputs = Digest::SHA256.digest(Digest::SHA256.digest(@out.map(&:to_payload).join))
 
         case (hash_type & 0x1f)
-          when SIGHASH_TYPE[:single]
-            hash_outputs = input_idx >= @out.size ? "\x00".ljust(32, "\x00") : Digest::SHA256.digest(Digest::SHA256.digest(@out[input_idx].to_payload))
-            hash_sequence = "\x00".ljust(32, "\x00")
-          when SIGHASH_TYPE[:none]
-            hash_sequence = hash_outputs = "\x00".ljust(32, "\x00")
+        when SIGHASH_TYPE[:single]
+          hash_outputs = if input_idx >= @out.size
+                           "\x00".ljust(32, "\x00")
+                         else
+                           Digest::SHA256.digest(Digest::SHA256.digest(@out[input_idx].to_payload))
+                         end
+          hash_sequence = "\x00".ljust(32, "\x00")
+        when SIGHASH_TYPE[:none]
+          hash_sequence = hash_outputs = "\x00".ljust(32, "\x00")
         end
 
         if (hash_type & SIGHASH_TYPE[:anyonecanpay]) != 0
-          hash_prevouts = hash_sequence ="\x00".ljust(32, "\x00")
+          hash_prevouts = hash_sequence = "\x00".ljust(32, "\x00")
         end
 
-        buf = [ [@ver].pack("V"), hash_prevouts, hash_sequence, outpoint,
-                script_code, amount, nsequence, hash_outputs, [@lock_time, hash_type].pack("VV")].join
+        buf = [[@ver].pack('V'), hash_prevouts, hash_sequence, outpoint, script_code,
+               amount, nsequence, hash_outputs, [@lock_time, hash_type].pack('VV')].join
 
-        Digest::SHA256.digest( Digest::SHA256.digest( buf ) )
+        Digest::SHA256.digest(Digest::SHA256.digest(buf))
       end
 
       def script_pubkey_from_outpoint_data(outpoint_data, outpoint_idx)

--- a/lib/bitcoin/protocol/txout.rb
+++ b/lib/bitcoin/protocol/txout.rb
@@ -2,9 +2,8 @@
 
 module Bitcoin
   module Protocol
-
+    # TxOut section of https://en.bitcoin.it/wiki/Protocol_documentation#tx
     class TxOut
-
       # output value (in base units; "satoshi")
       attr_accessor :value
 
@@ -14,16 +13,20 @@ module Bitcoin
       # p2sh redeem script (optional, not included in the serialized binary format)
       attr_accessor :redeem_script
 
-      def initialize *args
+      def initialize(*args)
         if args.size == 2
-          @value, @pk_script_length, @pk_script = args[0], args[1].bytesize, args[1]
+          @value = args[0]
+          @pk_script_length = args[1].bytesize
+          @pk_script = args[1]
         else
           @value, @pk_script_length, @pk_script = *args
         end
       end
 
       def ==(other)
-        @value == other.value && @pk_script == other.pk_script rescue false
+        @value == other.value && @pk_script == other.pk_script
+      rescue StandardError
+        false
       end
 
       # parse raw binary data for transaction output
@@ -34,18 +37,20 @@ module Bitcoin
       end
 
       def self.from_io(buf)
-        txout = new; txout.parse_data_from_io(buf); txout
+        txout = new
+        txout.parse_data_from_io(buf)
+        txout
       end
 
       # parse raw binary data for transaction output
       def parse_data_from_io(buf)
         clear_parsed_script_cache
-        @value = buf.read(8).unpack("Q")[0]
+        @value = buf.read(8).unpack('Q')[0]
         @pk_script_length = Protocol.unpack_var_int_from_io(buf)
         @pk_script = buf.read(@pk_script_length)
       end
 
-      alias :parse_payload :parse_data
+      alias parse_payload parse_data
 
       def parsed_script
         @parsed_script ||= Bitcoin::Script.new(pk_script)
@@ -56,7 +61,7 @@ module Bitcoin
       end
 
       def to_payload
-        [@value].pack("Q") << Protocol.pack_var_int(@pk_script_length) << @pk_script
+        [@value].pack('Q') << Protocol.pack_var_int(@pk_script_length) << @pk_script
       end
 
       def to_null_payload
@@ -64,8 +69,8 @@ module Bitcoin
       end
 
       def to_hash(options = {})
-        h = { 'value' => "%.8f" % (@value / 100000000.0),
-          'scriptPubKey' => parsed_script.to_string }
+        h = { 'value' => format('%.8f', (@value / 100_000_000.0)),
+              'scriptPubKey' => parsed_script.to_string }
         if options[:with_address]
           addrs = parsed_script.get_addresses
           h['address'] = addrs.first if addrs.size == 1
@@ -74,7 +79,7 @@ module Bitcoin
       end
 
       def self.from_hash(output)
-        amount = output['value'] ? output['value'].gsub('.','').to_i : output['amount']
+        amount = output['value'] ? output['value'].delete('.').to_i : output['amount']
         script = Script.binary_from_string(output['scriptPubKey'] || output['script'])
         new(amount, script)
       end
@@ -82,14 +87,15 @@ module Bitcoin
       # set pk_script and pk_script_length
       def pk_script=(pk_script)
         clear_parsed_script_cache
-        @pk_script_length, @pk_script = pk_script.bytesize, pk_script
+        @pk_script_length = pk_script.bytesize
+        @pk_script = pk_script
       end
 
-      alias :amount   :value
-      alias :amount=  :value=
+      alias amount   value
+      alias amount=  value=
 
-      alias :script   :pk_script
-      alias :script=  :pk_script=
+      alias script   pk_script
+      alias script=  pk_script=
 
       # create output spending +value+ btc (base units) to +address+
       def self.value_to_address(value, address)
@@ -97,8 +103,6 @@ module Bitcoin
         raise "Script#pk_script nil with address #{address}" unless pk_script
         new(value, pk_script)
       end
-
     end
-
   end
 end

--- a/lib/bitcoin/protocol/version.rb
+++ b/lib/bitcoin/protocol/version.rb
@@ -2,7 +2,6 @@
 
 module Bitcoin
   module Protocol
-
     # https://en.bitcoin.it/wiki/Protocol_specification#version
     class Version
       # services bit constants
@@ -11,78 +10,92 @@ module Bitcoin
 
       attr_reader :fields
 
-      def initialize(opts={})
+      def initialize(opts = {})
         @fields = {
-          :version    => Bitcoin.network[:protocol_version],
-          :services   => NODE_NETWORK,
-          :time       => Time.now.tv_sec,
-          :from       => "127.0.0.1:8333",
-          :to         => "127.0.0.1:8333",
-          :nonce      => Bitcoin::Protocol::Uniq,
-          :user_agent => "/bitcoin-ruby:#{Bitcoin::VERSION}/",
-          :last_block => 0, # 188617
-          :relay      => true # BIP0037
-        }.merge( opts.reject{|k,v| v == nil } )
+          version: Bitcoin.network[:protocol_version],
+          services: NODE_NETWORK,
+          time: Time.now.tv_sec,
+          from: '127.0.0.1:8333',
+          to: '127.0.0.1:8333',
+          nonce: Bitcoin::Protocol::Uniq,
+          user_agent: "/bitcoin-ruby:#{Bitcoin::VERSION}/",
+          last_block: 0, # 188617
+          relay: true # BIP0037
+        }.merge(opts.reject { |_k, v| v.nil? })
       end
 
       def to_payload
         [
-          @fields.values_at(:version, :services, :time).pack("VQQ"),
+          @fields.values_at(:version, :services, :time).pack('VQQ'),
           pack_address_field(@fields[:from]),
           pack_address_field(@fields[:to]),
-          @fields.values_at(:nonce).pack("Q"),
+          @fields.values_at(:nonce).pack('Q'),
           Protocol.pack_var_string(@fields[:user_agent]),
-          @fields.values_at(:last_block).pack("V"),
-          Protocol.pack_boolean(@fields[:relay]) # Satoshi 0.8.6 doesn't send this but it does respect it
+          @fields.values_at(:last_block).pack('V'),
+          # Satoshi 0.8.6 doesn't send this but it does respect it
+          Protocol.pack_boolean(@fields[:relay])
         ].join
       end
 
       def to_pkt
-        Bitcoin::Protocol.pkt("version", to_payload)
+        Bitcoin::Protocol.pkt('version', to_payload)
       end
 
       def parse(payload)
-        version, services, timestamp, to, from, nonce, payload = payload.unpack("VQQa26a26Qa*")
-        to, from = unpack_address_field(to), unpack_address_field(from)
+        version, services, timestamp, to, from, nonce, payload = payload.unpack('VQQa26a26Qa*')
+        to = unpack_address_field(to)
+        from = unpack_address_field(from)
         user_agent, payload = Protocol.unpack_var_string(payload)
-        last_block, payload = payload.unpack("Va*")
-        relay, payload = unpack_relay_field(version, payload)
+        last_block, payload = payload.unpack('Va*')
+        relay, = unpack_relay_field(version, payload)
 
         @fields = {
-         :version => version, :services => services, :time => timestamp,
-         :from => from, :to => to, :nonce => nonce,
-         :user_agent => user_agent.to_s, :last_block => last_block, :relay => relay
+          version: version, services: services, time: timestamp,
+          from: from, to: to, nonce: nonce,
+          user_agent: user_agent.to_s, last_block: last_block, relay: relay
         }
         self
       end
 
       def unpack_address_field(payload)
-        ip, port = payload.unpack("x8x12a4n")
-        "#{ip.unpack("C*").join(".")}:#{port}"
+        ip, port = payload.unpack('x8x12a4n')
+        "#{ip.unpack('C*').join('.')}:#{port}"
       end
 
       def pack_address_field(addr_str)
-        host, port = addr_str.split(":")
+        host, port = addr_str.split(':')
         port = port ? port.to_i : 8333
         sockaddr = Socket.pack_sockaddr_in(port, host)
-        #raise "invalid IPv4 Address: #{addr}" unless sockaddr[0...2] == "\x02\x00"
-        port, host = sockaddr[2...4], sockaddr[4...8]
-        [[1].pack("Q"), "\x00"*10, "\xFF\xFF",  host, port].join
+        # raise "invalid IPv4 Address: #{addr}" unless sockaddr[0...2] == "\x02\x00"
+        port = sockaddr[2...4]
+        host = sockaddr[4...8]
+        [[1].pack('Q'), "\x00" * 10, "\xFF\xFF", host, port].join
       end
 
       # BIP0037: this field starts with version 70001 and is allowed to be missing, defaults to true
       def unpack_relay_field(version, payload)
-        ( version >= 70001 and payload ) ? Protocol.unpack_boolean(payload) : [ true, nil ]
+        version >= 70_001 && payload ? Protocol.unpack_boolean(payload) : [true, nil]
       end
 
       def uptime
         @fields[:time] - Time.now.tv_sec
       end
 
-      def method_missing(*a); (@fields[a.first] rescue nil) or super(*a); end
+      def method_missing(*a)
+        @fields[a.first]
+      rescue StandardError
+        super
+      end
 
-      def self.parse(payload); new.parse(payload); end
+      def respond_to_missing?(*a)
+        @fields[a.first]
+      rescue StandardError
+        super
+      end
+
+      def self.parse(payload)
+        new.parse(payload)
+      end
     end
-
   end
 end


### PR DESCRIPTION
This patch begins the process of getting the `bitcoin-ruby` codebase conformed to a uniform code quality standard using `rubocop`.

- Adds a .rubocop.yml file with some sensible defaults
- Ensures that all files in the `lib/bitcoin/protocol` directory have 0 `rubocop` offenses

