### PR TITLE
Add to_custom_script method

### DIFF
--- a/lib/bitcoin/script.rb
+++ b/lib/bitcoin/script.rb
@@ -833,6 +833,15 @@ class Bitcoin::Script
     return buf + pack_pushdata( [data].pack("H*") )
   end
 
+  # Sometimes you might want to include a script with a custom stack
+  def self.to_custom_script(data = nil)
+    if data
+      [data].pack("H*")
+    else
+      [OP_NOP].pack("C")
+    end
+  end
+
   # generate input script sig spending a pubkey output with given +signature+ and +pubkey+.
   # returns a raw binary script sig of the form:
   #  <signature> [<pubkey>]

--- a/spec/unit/bitcoin/script/script_spec.rb
+++ b/spec/unit/bitcoin/script/script_spec.rb
@@ -609,6 +609,12 @@ describe Bitcoin::Script do
       expect(Bitcoin::Script.to_p2sh_script(hash160))
         .to eq(Bitcoin::Script.from_string("OP_HASH160 #{hash160} OP_EQUAL").raw)
     end
+
+    it 'should generate a custom script' do
+      script = '6a0400004b5014000000004269747072696d0000000000000f4240'
+      expect(Bitcoin::Script.to_custom_script(script))
+        .to eq('6a0400004b5014000000004269747072696d0000000000000f4240'.htb)
+    end
   end
 
   describe 'generate script sigs' do


### PR DESCRIPTION
Add to_custom_script method because in some situations you might want to
include the script directly, like signing a transaction using build_tx with a custom output.
Example: https://github.com/bitprim/bitprim-keoken/blob/master/keoken-whitepaper.md