### PR TITLE
Fix loading openssl 1.1.1h

### DIFF
--- a/lib/bitcoin/ffi/openssl.rb
+++ b/lib/bitcoin/ffi/openssl.rb
@@ -11,7 +11,7 @@ module Bitcoin
       ffi_lib 'libeay32', 'ssleay32'
     else
       ffi_lib [
-        'libssl.so.1.1.0', 'libssl.so.1.1',
+        'libssl.so.1.1.0', 'libssl.so.1.1', 'libssl.1.1',
         'libssl.so.1.0.0', 'libssl.so.10',
         'ssl'
       ]


### PR DESCRIPTION
support loading libssl.1.1.dylib

```
/usr/local/opt/openssl@1.1/lib
➜  lib ll
total 15144
drwxr-xr-x  4 tobi  staff   128B Sep 22 19:55 engines-1.1
-r--r--r--  1 tobi  staff   2.3M Nov 30 12:09 libcrypto.1.1.dylib
-r--r--r--  1 tobi  staff   3.9M Sep 22 19:55 libcrypto.a
lrwxr-xr-x  1 tobi  staff    19B Sep 22 19:55 libcrypto.dylib -> libcrypto.1.1.dylib
-r--r--r--  1 tobi  staff   491K Nov 30 12:09 libssl.1.1.dylib
-r--r--r--  1 tobi  staff   707K Sep 22 19:55 libssl.a
lrwxr-xr-x  1 tobi  staff    16B Sep 22 19:55 libssl.dylib -> libssl.1.1.dylib
drwxr-xr-x  5 tobi  staff   160B Nov 30 12:09 pkgconfig
```
1.1.1h only have `libssl.1.1.dylib` not `libssl.so.1.1.dylib` (correct if i'm wrong)
