### PR TITLE
openssl 3.0 support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+ARG RUBY_VERSION=3.2.2
+FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "name": "Ruby Bitcoin Development",
+  "dockerFile": "Dockerfile",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Shopify.ruby-lsp"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "ruby.useBundler": true,
+        "ruby.useLanguageServer": true,
+        "ruby.lint": {
+          "rubocop": true
+        }
+      }
+    }
+  },
+  "forwardPorts": [],
+  "postCreateCommand": "bundle install",
+  "remoteUser": "vscode"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,10 @@ spec-rspec/examples.txt
 *~
 \#*\#
 .\#*
+
+# VS Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,9 @@ GEM
     bacon (1.2.0)
     byebug (10.0.2)
     coderay (1.1.3)
+    debug (1.9.2)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     diff-lcs (1.3)
     docile (1.3.1)
     eventmachine (1.2.7)
@@ -20,8 +23,12 @@ GEM
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
+    io-console (0.7.2)
+    irb (1.14.1)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     jaro_winkler (1.5.1)
-    json (2.1.0)
+    json (2.8.2)
     method_source (0.9.2)
     minitest (5.11.3)
     parallel (1.12.1)
@@ -34,8 +41,14 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
+    psych (5.2.0)
+      stringio
     rainbow (3.0.0)
     rake (12.3.3)
+    rdoc (6.8.1)
+      psych (>= 4.0.0)
+    reline (0.5.11)
+      io-console (~> 0.5)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -66,6 +79,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    stringio (3.1.2)
     unicode-display_width (1.4.0)
 
 PLATFORMS
@@ -74,6 +88,7 @@ PLATFORMS
 DEPENDENCIES
   bacon (~> 1.2.0)
   bitcoin-ruby!
+  debug
   minitest (~> 5.11.3)
   pry (~> 0.11.3)
   pry-byebug (~> 3.6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,17 +12,17 @@ GEM
     ast (2.4.0)
     bacon (1.2.0)
     byebug (10.0.2)
-    coderay (1.1.2)
+    coderay (1.1.3)
     diff-lcs (1.3)
     docile (1.3.1)
     eventmachine (1.2.7)
-    ffi (1.9.25)
-    ffi-compiler (1.0.1)
-      ffi (>= 1.0.0)
+    ffi (1.17.0)
+    ffi-compiler (1.3.2)
+      ffi (>= 1.15.5)
       rake
     jaro_winkler (1.5.1)
     json (2.1.0)
-    method_source (0.9.0)
+    method_source (0.9.2)
     minitest (5.11.3)
     parallel (1.12.1)
     parser (2.5.1.2)
@@ -35,7 +35,7 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     rainbow (3.0.0)
-    rake (12.3.1)
+    rake (12.3.3)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -58,8 +58,9 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
-    scrypt (3.0.5)
+    scrypt (3.0.8)
       ffi-compiler (>= 1.0, < 2.0)
+      rake (>= 9, < 14)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -82,4 +83,4 @@ DEPENDENCIES
   simplecov (~> 0.16.1)
 
 BUNDLED WITH
-   1.17.3
+   2.5.23

--- a/bitcoin-ruby.gemspec
+++ b/bitcoin-ruby.gemspec
@@ -24,4 +24,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ffi'
   s.add_runtime_dependency 'scrypt' # required by Litecoin
   s.add_runtime_dependency 'eventmachine' # required for connection code
+
+  # Add development dependencies
+  s.add_development_dependency 'rspec', '~> 3.12'
+  s.add_development_dependency 'pry', '~> 0.13.1'  # Downgrade Pry to a more compatible version
 end

--- a/bitcoin-ruby.gemspec
+++ b/bitcoin-ruby.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |s|
 
   # Add development dependencies
   s.add_development_dependency 'rspec', '~> 3.12'
-  s.add_development_dependency 'pry', '~> 0.13.1'  # Downgrade Pry to a more compatible version
+  s.add_development_dependency 'debug'
 end

--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -443,6 +443,7 @@ module Bitcoin
       return false unless valid_address?(address)
       return false unless signature
       return false unless signature.bytesize == 65
+
       hash = bitcoin_signed_message_hash(message)
       pubkey = OpenSSL_EC.recover_compact(hash, signature)
       pubkey_to_address(pubkey) == address if pubkey

--- a/lib/bitcoin/key.rb
+++ b/lib/bitcoin/key.rb
@@ -183,7 +183,7 @@ module Bitcoin
       addresshash = Digest::SHA256.digest( Digest::SHA256.digest( self.addr ) )[0...4]
 
       require 'scrypt' unless defined?(::SCrypt::Engine)
-      buf = SCrypt::Engine.__sc_crypt(passphrase, addresshash, 16384, 8, 8, 64)
+      buf = SCrypt::Engine.scrypt(passphrase, addresshash, 16384, 8, 8, 64)
       derivedhalf1, derivedhalf2 = buf[0...32], buf[32..-1]
 
       aes = proc{|k,a,b|
@@ -212,7 +212,7 @@ module Bitcoin
       raise "Invalid checksum"  unless Digest::SHA256.digest(Digest::SHA256.digest(version + flagbyte + addresshash + encryptedhalf1 + encryptedhalf2))[0...4] == checksum
 
       require 'scrypt' unless defined?(::SCrypt::Engine)
-      buf = SCrypt::Engine.__sc_crypt(passphrase, addresshash, 16384, 8, 8, 64)
+      buf = SCrypt::Engine.scrypt(passphrase, addresshash, 16384, 8, 8, 64)
       derivedhalf1, derivedhalf2 = buf[0...32], buf[32..-1]
 
       aes = proc{|k,a|

--- a/lib/bitcoin/key.rb
+++ b/lib/bitcoin/key.rb
@@ -48,7 +48,7 @@ module Bitcoin
 
     # Generate new priv/pub key.
     def generate
-      @key
+      @key = Bitcoin::PKeyEC.generate_key
     end
 
     # Get the private key (in hex).
@@ -261,32 +261,13 @@ module Bitcoin
     def set_priv(priv)
       value = priv.to_i(16)
       raise 'private key is not on curve' unless MIN_PRIV_KEY_MOD_ORDER <= value && value <= MAX_PRIV_KEY_MOD_ORDER
-
-      # OpenSSL 3 compatibility
-      bn = OpenSSL::BN.from_hex(priv)
-      if @key.respond_to?(:set_private_key)
-        @key.set_private_key(bn)
-      else
         @key.private_key = bn
-      end
     end
 
     # Set +pub+ as the new public key (converting from hex).
     def set_pub(pub, compressed = nil)
       @pubkey_compressed = compressed == nil ? self.class.is_compressed_pubkey?(pub) : compressed
-
-      # OpenSSL 3 compatibility
-      group = @key.group
-      asn1 = OpenSSL::ASN1::Sequence([
-        OpenSSL::ASN1::Sequence([
-          OpenSSL::ASN1::ObjectId("id-ecPublicKey"),
-          OpenSSL::ASN1::ObjectId(group.curve_name)
-        ]),
-        OpenSSL::ASN1::BitString(OpenSSL::PKey::EC::Point.from_hex(group, pub).to_octet_string(:uncompressed))
-      ])
-
-      new_key = OpenSSL::PKey::EC.new(asn1.to_der)
-      @key.public_key = new_key.public_key
+      @key.public_key = OpenSSL::PKey::EC::Point.from_hex(@key.group, pub)
     end
 
     def self.is_compressed_pubkey?(pub)

--- a/lib/bitcoin/key.rb
+++ b/lib/bitcoin/key.rb
@@ -155,7 +155,7 @@ module Bitcoin
 
       version = signature.unpack('C')[0]
       return nil if version < 27 or version > 34
- 
+
       compressed = (version >= 31) ? (version -= 4; true) : false
 
       hash = Bitcoin.bitcoin_signed_message_hash(data)
@@ -261,7 +261,7 @@ module Bitcoin
     def set_priv(priv)
       value = priv.to_i(16)
       raise 'private key is not on curve' unless MIN_PRIV_KEY_MOD_ORDER <= value && value <= MAX_PRIV_KEY_MOD_ORDER
-      
+
       # OpenSSL 3 compatibility
       bn = OpenSSL::BN.from_hex(priv)
       if @key.respond_to?(:set_private_key)
@@ -274,7 +274,7 @@ module Bitcoin
     # Set +pub+ as the new public key (converting from hex).
     def set_pub(pub, compressed = nil)
       @pubkey_compressed = compressed == nil ? self.class.is_compressed_pubkey?(pub) : compressed
-      
+
       # OpenSSL 3 compatibility
       group = @key.group
       asn1 = OpenSSL::ASN1::Sequence([
@@ -284,7 +284,7 @@ module Bitcoin
         ]),
         OpenSSL::ASN1::BitString(OpenSSL::PKey::EC::Point.from_hex(group, pub).to_octet_string(:uncompressed))
       ])
-      
+
       new_key = OpenSSL::PKey::EC.new(asn1.to_der)
       @key.public_key = new_key.public_key
     end

--- a/lib/bitcoin/key.rb
+++ b/lib/bitcoin/key.rb
@@ -261,7 +261,7 @@ module Bitcoin
     def set_priv(priv)
       value = priv.to_i(16)
       raise 'private key is not on curve' unless MIN_PRIV_KEY_MOD_ORDER <= value && value <= MAX_PRIV_KEY_MOD_ORDER
-        @key.private_key = bn
+      @key.private_key = OpenSSL::BN.from_hex(priv)
     end
 
     # Set +pub+ as the new public key (converting from hex).

--- a/lib/bitcoin/key.rb
+++ b/lib/bitcoin/key.rb
@@ -259,8 +259,24 @@ module Bitcoin
 
     # Set +priv+ as the new private key (converting from hex).
     def set_priv(priv)
+      # Convert to string and strip whitespace
+      priv = priv.to_s.strip
+      
+      # Validate hex string format
+      unless priv.match?(/\A[0-9a-fA-F]+\z/)
+        raise ArgumentError, "Private key must be a valid hexadecimal string, got: #{priv.inspect}"
+      end
+      
+      # Validate length (64 hex chars = 32 bytes)
+      unless priv.length == 64
+        raise ArgumentError, "Private key must be exactly 64 hex characters (got #{priv.length})"
+      end
+      
       value = priv.to_i(16)
-      raise 'private key is not on curve' unless MIN_PRIV_KEY_MOD_ORDER <= value && value <= MAX_PRIV_KEY_MOD_ORDER
+      unless MIN_PRIV_KEY_MOD_ORDER <= value && value <= MAX_PRIV_KEY_MOD_ORDER
+        raise ArgumentError, 'Private key value is not within valid range (must be between 1 and n-1 where n is the order of the secp256k1 curve)'
+      end
+      
       @key.private_key = OpenSSL::BN.from_hex(priv)
     end
 

--- a/lib/bitcoin/pkey_ec.rb
+++ b/lib/bitcoin/pkey_ec.rb
@@ -1,11 +1,10 @@
 module Bitcoin
-  class PKeyEC
+  class PKeyEC #< OpenSSL::PKey::EC
 
     CURVE = 'secp256k1'
 
-    attr_reader :private_key, :group
+    attr_reader :group, :private_key, :public_key
 
-    attr_accessor :public_key, :private_key
 
     def private_key_hex; private_key.to_hex.rjust(64, '0'); end
     def public_key_hex;  public_key.to_hex.rjust(130, '0'); end
@@ -18,52 +17,51 @@ module Bitcoin
       OpenSSL::PKey::EC.generate(CURVE)
     end
 
-    def private_key
-      @public_key = restore_public_key(@private_key)
+    def public_key=(public_key_bn)
+      @public_key = public_key_bn
+    end
 
-      private_key_bn   = OpenSSL::BN.new(@private_key, 16)
-      public_key_bn    = OpenSSL::BN.new(@public_key, 16)
-      public_key_point = OpenSSL::PKey::EC::Point.new(@group, public_key_bn)
-
+    def private_key=(private_key_bn)
+      @public_key = restore_public_key(private_key_bn)
       asn1 = OpenSSL::ASN1::Sequence(
         [
           OpenSSL::ASN1::Integer.new(1),
           OpenSSL::ASN1::OctetString(private_key_bn.to_s(2)),
           OpenSSL::ASN1::ObjectId(CURVE, 0, :EXPLICIT),
-          OpenSSL::ASN1::BitString(public_key_point.to_octet_string(:uncompressed), 1, :EXPLICIT)
+          OpenSSL::ASN1::BitString(@public_key.to_octet_string(:uncompressed), 1, :EXPLICIT)
         ]
       )
-
-      OpenSSL::PKey::EC.new(asn1.to_der).private_key
+      @pk = OpenSSL::PKey::EC.new(asn1.to_der)
+      @private_key = @pk.private_key
     end
 
-    def public_key
-      return nil unless @private_key
-      @public_key = restore_public_key(@private_key)
-      public_key_bn    = OpenSSL::BN.new(@public_key, 16)
-      public_key_point = OpenSSL::PKey::EC::Point.new(@group, public_key_bn)
+    def dsa_sign_asn1(data)
+      @pk.dsa_sign_asn1(data)
+    end
 
+    def dsa_verify_asn1(data, signature)
+      initialize_from_public_key unless @pk
+      @pk.dsa_verify_asn1(data, signature)
+    end
+
+    def initialize_from_public_key
       asn1 = OpenSSL::ASN1::Sequence.new(
         [
           OpenSSL::ASN1::Sequence.new([
                                         OpenSSL::ASN1::ObjectId.new('id-ecPublicKey'),
                                         OpenSSL::ASN1::ObjectId.new(@group.curve_name)
                                       ]),
-          OpenSSL::ASN1::BitString.new(public_key_point.to_octet_string(:uncompressed))
+          OpenSSL::ASN1::BitString.new(@public_key.to_octet_string(:uncompressed))
         ]
       )
-      OpenSSL::PKey::EC.new(asn1.to_der).public_key
+      @pk = OpenSSL::PKey::EC.new(asn1.to_der)
     end
 
     private
 
-    def restore_public_key(private_key)
-      private_bn = OpenSSL::BN.new private_key, 16
-      group = OpenSSL::PKey::EC::Group.new CURVE
+    def restore_public_key(private_bn)
       public_bn = group.generator.mul(private_bn).to_bn
-      public_bn = OpenSSL::PKey::EC::Point.new(group, public_bn).to_bn
-
-      public_bn.to_s(16).downcase
+      public_bn = OpenSSL::PKey::EC::Point.new(@group, public_bn)
     end
   end
 end

--- a/lib/bitcoin/pkey_ec.rb
+++ b/lib/bitcoin/pkey_ec.rb
@@ -1,0 +1,69 @@
+module Bitcoin
+  class PKeyEC
+
+    CURVE = 'secp256k1'
+
+    attr_reader :private_key, :group
+
+    attr_accessor :public_key, :private_key
+
+    def private_key_hex; private_key.to_hex.rjust(64, '0'); end
+    def public_key_hex;  public_key.to_hex.rjust(130, '0'); end
+
+    def initialize
+      @group = OpenSSL::PKey::EC::Group.new(CURVE)
+    end
+
+    def self.generate_key
+      OpenSSL::PKey::EC.generate(CURVE)
+    end
+
+    def private_key
+      @public_key = restore_public_key(@private_key)
+
+      private_key_bn   = OpenSSL::BN.new(@private_key, 16)
+      public_key_bn    = OpenSSL::BN.new(@public_key, 16)
+      public_key_point = OpenSSL::PKey::EC::Point.new(@group, public_key_bn)
+
+      asn1 = OpenSSL::ASN1::Sequence(
+        [
+          OpenSSL::ASN1::Integer.new(1),
+          OpenSSL::ASN1::OctetString(private_key_bn.to_s(2)),
+          OpenSSL::ASN1::ObjectId(CURVE, 0, :EXPLICIT),
+          OpenSSL::ASN1::BitString(public_key_point.to_octet_string(:uncompressed), 1, :EXPLICIT)
+        ]
+      )
+
+      OpenSSL::PKey::EC.new(asn1.to_der).private_key
+    end
+
+    def public_key
+      return nil unless @private_key
+      @public_key = restore_public_key(@private_key)
+      public_key_bn    = OpenSSL::BN.new(@public_key, 16)
+      public_key_point = OpenSSL::PKey::EC::Point.new(@group, public_key_bn)
+
+      asn1 = OpenSSL::ASN1::Sequence.new(
+        [
+          OpenSSL::ASN1::Sequence.new([
+                                        OpenSSL::ASN1::ObjectId.new('id-ecPublicKey'),
+                                        OpenSSL::ASN1::ObjectId.new(@group.curve_name)
+                                      ]),
+          OpenSSL::ASN1::BitString.new(public_key_point.to_octet_string(:uncompressed))
+        ]
+      )
+      OpenSSL::PKey::EC.new(asn1.to_der).public_key
+    end
+
+    private
+
+    def restore_public_key(private_key)
+      private_bn = OpenSSL::BN.new private_key, 16
+      group = OpenSSL::PKey::EC::Group.new CURVE
+      public_bn = group.generator.mul(private_bn).to_bn
+      public_bn = OpenSSL::PKey::EC::Point.new(group, public_bn).to_bn
+
+      public_bn.to_s(16).downcase
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'json'
 # Code coverage generation
 require 'simplecov'
 
+require 'debug'
 SimpleCov.start do
   add_group('Bitcoin') do |file|
     ['bitcoin.rb', 'opcodes.rb', 'script.rb', 'key.rb'].include?(

--- a/spec/unit/bitcoin/bitcoin_spec.rb
+++ b/spec/unit/bitcoin/bitcoin_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# require 'pry'
+require 'debug'
 require 'spec_helper'
 
 describe Bitcoin do
@@ -973,14 +973,16 @@ describe Bitcoin do
 
   describe 'bitcoin base58 test vectors' do
     # Port of Bitcoin Core test vectors.
-    # https://github.com/bitcoin/bitcoin/blob/595a7bab23bc21049526229054ea1fff1a29c0bf/src/test/base58_tests.cpp#L139
+    # https://github.com/bitcoin/bitcoin/blob/master/src/test/base58_tests.cpp
     let(:valid_base58_keys) do
-      JSON.parse(fixtures_file('base58_keys_valid.json'))
+      path = File.join(File.dirname(__FILE__), '../../fixtures/base58_keys_valid.json')
+      JSON.parse(File.read(path))
     end
     # Port of Bitcoin Core test vectors.
-    # https://github.com/bitcoin/bitcoin/blob/595a7bab23bc21049526229054ea1fff1a29c0bf/src/test/base58_tests.cpp#L179
+    # https://github.com/bitcoin/bitcoin/blob/master/src/test/base58_tests.cpp
     let(:invalid_base58_keys) do
-      JSON.parse(fixtures_file('base58_keys_invalid.json'))
+      path = File.join(File.dirname(__FILE__), '../../fixtures/base58_keys_invalid.json')
+      JSON.parse(File.read(path))
     end
 
     it 'passes the valid keys cases' do
@@ -1014,8 +1016,7 @@ describe Bitcoin do
     end
 
     it 'fails the invalid keys cases' do
-      test_cases = JSON.parse(fixtures_file('base58_keys_invalid.json'))
-      test_cases.each do |test_case|
+      invalid_base58_keys.each do |test_case|
         address = test_case[0]
 
         %i[bitcoin testnet3 regtest].each do |network_name|

--- a/spec/unit/bitcoin/bitcoin_spec.rb
+++ b/spec/unit/bitcoin/bitcoin_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'pry'
+# require 'pry'
 require 'spec_helper'
 
 describe Bitcoin do

--- a/spec/unit/bitcoin/key_spec.rb
+++ b/spec/unit/bitcoin/key_spec.rb
@@ -359,16 +359,73 @@ describe Bitcoin::Key do
       Bitcoin::Key.new(
         'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141'
       )
-    end.to raise_error(RuntimeError, 'private key is not on curve')
+    end.to raise_error(ArgumentError, 'Private key value is not within valid range (must be between 1 and n-1 where n is the order of the secp256k1 curve)')
 
     expect do
-      Bitcoin::Key.new('00')
-    end.to raise_error(RuntimeError, 'private key is not on curve')
+      Bitcoin::Key.new('0000000000000000000000000000000000000000000000000000000000000000')
+    end.to raise_error(ArgumentError, 'Private key value is not within valid range (must be between 1 and n-1 where n is the order of the secp256k1 curve)')
 
     Bitcoin::Key.new(
       'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140'
     )
-    Bitcoin::Key.new('01')
+    Bitcoin::Key.new('0000000000000000000000000000000000000000000000000000000000000001')
+  end
+
+  describe 'private key validation' do
+    it 'should reject non-hexadecimal strings' do
+      ['doudou', 'hello', 'xyz123', 'test!@#', 'gggggg'].each do |invalid_input|
+        expect do
+          Bitcoin::Key.new(invalid_input)
+        end.to raise_error(ArgumentError, /must be a valid hexadecimal string/)
+      end
+    end
+
+    it 'should reject private keys with invalid length' do
+      # Too short
+      expect do
+        Bitcoin::Key.new('00ff')
+      end.to raise_error(ArgumentError, 'Private key must be exactly 64 hex characters (got 4)')
+      
+      expect do
+        Bitcoin::Key.new('0' * 63)
+      end.to raise_error(ArgumentError, 'Private key must be exactly 64 hex characters (got 63)')
+      
+      # Too long
+      expect do
+        Bitcoin::Key.new('0' * 65)
+      end.to raise_error(ArgumentError, 'Private key must be exactly 64 hex characters (got 65)')
+    end
+
+    it 'should reject empty or whitespace-only strings' do
+      ['', '   ', "\n", "\t"].each do |invalid_input|
+        expect do
+          Bitcoin::Key.new(invalid_input)
+        end.to raise_error(ArgumentError)
+      end
+    end
+
+    it 'should accept valid 64-character hex strings' do
+      valid_keys = [
+        '0000000000000000000000000000000000000000000000000000000000000001',
+        '5e104fee0f23f6a6a5f0f30db5de3b6f01dac6bb9adf5a8db5dea29f4c2c8912',
+        'fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140'
+      ]
+      
+      valid_keys.each do |key|
+        k = Bitcoin::Key.new(key)
+        expect(k.priv).to eq(key.downcase)
+      end
+    end
+
+    it 'should handle uppercase hex characters' do
+      k = Bitcoin::Key.new('ABCDEF1234567890' * 4)
+      expect(k.priv).to eq('abcdef1234567890' * 4)
+    end
+
+    it 'should strip leading/trailing whitespace' do
+      k = Bitcoin::Key.new('  0000000000000000000000000000000000000000000000000000000000000001  ')
+      expect(k.priv).to eq('0000000000000000000000000000000000000000000000000000000000000001')
+    end
   end
 
   describe 'Bitcoin::OpenSSL_EC' do

--- a/spec/unit/bitcoin/pkey_ec_spec.rb
+++ b/spec/unit/bitcoin/pkey_ec_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+module Bitcoin
+  describe PKeyEC do
+    let(:pkey) { PKeyEC }
+    describe '.generate_key' do
+      let(:generated_key) { Bitcoin::PKeyEC.generate_key }
+
+      it 'generates a valid EC key' do
+        expect(generated_key).to be_a(OpenSSL::PKey::EC)
+      end
+
+      it 'generates a key with private key component' do
+        expect(generated_key.private_key?).to be true
+      end
+
+      it 'generates a key with public key component' do
+        expect(generated_key.public_key?).to be true
+      end
+
+      it 'generates a key on the secp256k1 curve' do
+        expect(generated_key.group.curve_name).to eq('secp256k1')
+      end
+
+      it 'generates unique keys on subsequent calls' do
+        key1 = pkey.generate_key
+        key2 = pkey.generate_key
+        expect(key1.private_key.to_s(16)).not_to eq(key2.private_key.to_s(16))
+      end
+    end
+
+    describe '#private_key' do
+      let(:key) { Bitcoin::PKeyEC.new }
+
+      it 'sets the private key' do
+        key.private_key = '0123456789abcdef'
+        expect(key.private_key.to_s(16)).to eq('0123456789ABCDEF')
+      end
+
+      it 'returns the public key' do
+        key.private_key = '0123456789abcdef'
+        expect(key.public_key_hex).to eq('041a1fd15fce078234aa292fc024178056bf006433c9b4bd208f59eb4c9efec95ba18af1fe46980989d3ff75bf9601121151ef46e2cfab8999408319ce8f3be725')
+      end
+    end
+  end
+end

--- a/spec/unit/bitcoin/pkey_ec_spec.rb
+++ b/spec/unit/bitcoin/pkey_ec_spec.rb
@@ -33,12 +33,12 @@ module Bitcoin
       let(:key) { Bitcoin::PKeyEC.new }
 
       it 'sets the private key' do
-        key.private_key = '0123456789abcdef'
+        key.private_key = OpenSSL::BN.new('0123456789abcdef', 16)
         expect(key.private_key.to_s(16)).to eq('0123456789ABCDEF')
       end
 
       it 'returns the public key' do
-        key.private_key = '0123456789abcdef'
+        key.private_key = OpenSSL::BN.new('0123456789abcdef', 16)
         expect(key.public_key_hex).to eq('041a1fd15fce078234aa292fc024178056bf006433c9b4bd208f59eb4c9efec95ba18af1fe46980989d3ff75bf9601121151ef46e2cfab8999408319ce8f3be725')
       end
     end


### PR DESCRIPTION
- [x] passing specs so far
  - rspec spec/unit/bitcoin/bitcoin_spec.rb
  - spec/unit/bitcoin/pkey_ec_spec.rb
  - spec/unit/bitcoin/key_spec.rb
  - spec/unit/bitcoin/builder_spec.rb
  - spec/unit/bitcoin/ext_key_spec.rb
  - spec/unit/bitcoin/network_spec.rb
  - spec/unit/bitcoin/bech32_spec.rb
  - spec/unit/bitcoin/bloom_filter_spec.rb

- [x] added devcontainer for vscode users
- [x] support ruby version to 3.2
